### PR TITLE
Add copy command that skips npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,13 @@ Example:
 ropm clean
 ```
 
+### copy
+Similar to [install](#install), but does not fetch missing dependencies from the registry. This command should be faster than [install](#install) as long as all the necessary dependencies are already downloaded.
+Example:
+```bash
+ropm copy
+```
+
 ### uninstall
 Uninstall one or more packages from both `node_modules` and `roku_modules`. This also updates the local `package.json` `dependencies` section
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { InstallCommand } from './commands/InstallCommand';
 import { InitCommand } from './commands/InitCommand';
 import { CleanCommand } from './commands/CleanCommand';
 import { UninstallCommand } from './commands/UninstallCommand';
+import { CopyCommand } from './commands/CopyCommand';
 
 new Promise((resolve, reject) => {
     // eslint-disable-next-line
@@ -40,6 +41,14 @@ new Promise((resolve, reject) => {
                 .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' });
         }, (args: any) => {
             const command = new CleanCommand(args);
+            command.run().then(resolve, reject);
+        })
+
+        .command('copy', 'Runs `clean` and then installs all ropm modules. Operates solely with the modules already downloaded, and will not download new modules from the registry.', (builder) => {
+            return builder
+                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' });
+        }, (args: any) => {
+            const command = new CopyCommand(args);
             command.run().then(resolve, reject);
         })
 

--- a/src/commands/CopyCommand.ts
+++ b/src/commands/CopyCommand.ts
@@ -1,0 +1,21 @@
+import { InstallCommand } from './InstallCommand';
+
+export class CopyCommand {
+    constructor(
+        public args: InitCommandArgs
+    ) {
+
+    }
+
+    public async run() {
+        const installCommand = new InstallCommand(this.args);
+        await installCommand.run(false);
+    }
+}
+
+export interface InitCommandArgs {
+    /**
+     * The current working directory for the command.
+     */
+    cwd?: string;
+}

--- a/src/commands/InstallCommand.ts
+++ b/src/commands/InstallCommand.ts
@@ -34,10 +34,12 @@ export class InstallCommand {
         }
     }
 
-    public async run(): Promise<void> {
+    public async run(runNpmInstall = true): Promise<void> {
         await this.loadHostPackageJson();
         await this.deleteAllRokuModulesFolders();
-        await this.npmInstall();
+        if (runNpmInstall) {
+            await this.npmInstall();
+        }
         await this.processModules();
     }
 


### PR DESCRIPTION
When doing local development of a ropm package (i.e. `ropm install ../some-local-package`), anytime you make a chance to that package, you need to run `ropm install` again to copy the files to the proper `roku_modules` folders. The downside of `ropm install` is that it will attempt to download any missing dependencies from the registry, which takes some time even when nothing has changed.

This PR adds a new command, `ropm copy`, which skips the registry check. The general workflow is as follows:

1. Perform a full install: `ropm install ../some-local-package`
2. Anytime you make changes to `../some-local-package`, run `ropm copy`, which will be faster than `ropm install`.