### PR TITLE
Add support for prefixing function references not used in a function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0]
 ### Added
- - `ropm.functionReferenceMatching` option that allows for expanded function name searching and prefixing. 
+ - Find and prefix all function identifiers across the entire package.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0]
 ### Added
- - `ropm.prefixMatching` option that allows for expanded function name searching and prefixing. 
+ - `ropm.functionReferenceMatching` option that allows for expanded function name searching and prefixing. 
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.6.0]
+### Added
+ - `ropm.prefixMatching` option that allows for expanded function name searching and prefixing. 
+
+
+
 ## [0.5.0]
 ### Added
  - `ropm copy` command that speeds up local development by skipping the registry check (i.e. internal `npm install` call)
@@ -88,3 +94,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.4.0]:   https://github.com/rokucommunity/ropm/compare/v0.3.0...v0.4.0
 [0.4.1]:   https://github.com/rokucommunity/ropm/compare/v0.4.0...v0.4.1
 [0.5.0]:   https://github.com/rokucommunity/ropm/compare/v0.4.1...v0.5.0
+[0.6.0]:   https://github.com/rokucommunity/ropm/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ Here is the current logic. Find all identifiers that:
      - `doSomething("param1", logWarning, "param3")`
  - are to the left of a closing parentheses
      - `performActionWithCallback("actionName", logWarning)`
- - are surrounded by parentheses
+ - are surrounded by parentheses (more on this below)
      - `log = (logWarning)`
 
 
@@ -465,8 +465,8 @@ For this reason, `ropm` will _NOT_ prefix function references preceed with a col
 Here's how you can safely use function references with this situation:
 ```BrightScript
 person = {
-    getName: (getNameFunc),
-    getAge: (getAgeFunc)
+    getName: (getName),
+    getAge: (getAge)
 }
 ```
 ### Finding function references is a package-wide operation

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Here's an example (**NOTE:** comments are included here for explanation purposes
 }
 ```
 
-## prefixMatching
+## Finding function references
 ropm is very efficient at at finding function definitions and function calls. However, there are valid patterns in BrightScript where a function reference is used without calling it. For example: 
 ```BrightScript
 sub writeToLog(message)
@@ -403,19 +403,19 @@ sub logWarning(message)
 end sub
 ```
 
-In this situation, the `logWarning` function is being assigned by its name. `ropm`'s default operating mode will not detect these usages, so `logWarning` will not be properly prefixed.
+In this situation, the `logWarning` function is being assigned by its name reference. `ropm`'s default operating mode will not detect these usages, so `logWarning` will not be properly prefixed.
 
-Detecting these usages is fairly resource-intensive, so we advise you avoid coding with these patterns whenever possible. However, if you absolutely need to support this pattern, then `ropm` has a configuration option called `prefixMatching` that enables discovery and prefixing of these identifiers. 
+Detecting these usages is fairly resource-intensive, so we advise you avoid coding with these patterns whenever possible. However, if you absolutely need to support this pattern, then `ropm` has a configuration option called `functionReferenceMatching` that enables discovery and prefixing of these identifiers. 
 
 ```js
 {
     "ropm": {
-        "prefixMatching": "expanded" //default is "strict"
+        "functionReferenceMatching": "expanded" //default is "strict"
     }
 }
 ```
 
-When `prefixMatching` is set to `"expanded"`, ropm will scan all of your package's BrightScript files for words that appear to be identifiers. Then, ropm will add prefixes to all identifiers that have the same name as functions in your package. 
+When `functionReferenceMatching` is set to `"expanded"`, ropm will scan all of your package's BrightScript files for words that appear to be identifiers. Then, ropm will add prefixes to all identifiers that have the same name as functions in your package. 
 
 Downsides to this approach:
  1. This operation is package-wide and does not operate on a per-scope basis, so it will prefix any local variable that shares a name with a function in your package.
@@ -431,4 +431,4 @@ Downsides to this approach:
 In order to keep `ropm` transformations fast and effective, there are several restrictions that you need to follow as a ropm package author:
 
 1. Using brs within CDATA blocks in xml files is not supported. Please keep all of your BrightScript code in `.brs` files
-2. Avoid using `ropm.prefixMode: "expanded"` unless absolutely necessary.
+2. Avoid using `ropm.functionReferenceMatching: "expanded"` unless absolutely necessary.

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Here is the current logic. Find all identifiers that:
 
 
 ### Caveats to finding function references
-Due to ambiguities in the Roku language, there is still one situation that is difficult to correctly identify without a full parser. Consider this statement:
+Due to ambiguities in the BrightScript language, there is still one situation that is difficult to correctly identify without a full parser. Consider this statement:
 ```BrightScript
 person = {
     getName: getName,

--- a/README.md
+++ b/README.md
@@ -345,12 +345,16 @@ ropm uninstall module1 module2 module3
 Here is some overview information to help `ropm` package authors get started:
 
  - `ropm` modules are simply [npm](https://www.npmjs.com/) packages with the `ropm` keyword (see [How to create a ropm package](#how-to-create-a-ropm-package))
+ - Follow semantic versioning **strictly**. Make major breaking changes as infrequently as possible. (see [Semantic Versioning](#semantic-versioning))
  - `ropm` rewrites every `pkg:/` path, so use string concatenation if you need to bypass this logic (see [File paths](#file-paths))
  - Don't give local variables the same names as functions in your package. (See [Finding function references](#finding-function-references))
+ - Wrap function references in parentheses to help `ropm` find them in your code (See [Finding function references: Caveats](#caveats))
  - Don't write BrightScript in XML `CDATA` blocks (See [BrightScript in XML CDATA blocks is unsupported](#brightScript-in-xml-cdata-blocks-is-unsupported))
+ - Don't define a baseline namespace. On install, `ropm` will prefix your package for you. (See [Prefixes](#prefixes))
  -  use the `ropm` options in `package.json` to customize various settings in your package
      - `ropm.rootDir` - where you want `roku_modules` installed within your package
      - `ropm.packageRootDir` where your package's files reside (i.e. `dist`, `build`, `./`, etc...)
+     - Don't use `ropm.noprefix`, as can not be used within published `ropm` packages.
 
 
 ## How to create a ropm package
@@ -406,21 +410,69 @@ Here's an example (**NOTE:** comments are included here for explanation purposes
 ```
 
 ## Finding function references
-ropm is very efficient at at finding function definitions and function calls. However, there are valid patterns in BrightScript where a function reference is used without calling it. For example: 
+`ropm` is very efficient at at finding function definitions and function calls. However, it's more difficult to find function references when the function is not part of a function call. For example, the `logWarning` function is being assigned by its name reference on line #2`: 
 ```BrightScript
-sub writeToLog(message)
-    log = logWarning
-    log(message);
-end sub
-
-sub logWarning(message)
-    print "warning: " + message
-end sub
+1 | sub writeToLog(message)
+2 |     log = logWarning
+3 |     log(message);
+4 | end sub
+5 | 
+6 | sub logWarning(message)
+7 |     print "warning: " + message
+8 | end sub
 ```
 
-In this situation, the `logWarning` function is being assigned by its name reference. ropm will scan all of your package's BrightScript files for all [identifiers](http://developer.roku.com/docs/references/brightscript/language/expressions-variables-types.md#identifiers). Then, ropm will add prefixes to all identifiers that have the same name as functions in your package. 
+`ropm` will smartly scan all of your package's BrightScript files for [identifiers](http://developer.roku.com/docs/references/brightscript/language/expressions-variables-types.md#identifiers) that might be function references. Then, ropm will add prefixes to all identifiers that have the same name as functions in your package. 
 
-**NOTE:** This operation is package-wide and does not operate on a per-scope basis, so it will prefix any local variable that shares a name with any function across your entire package. While the code will still run, it might appear strange to see `ropm`-specific prefixes on local variables, so we recommend that you do not give local variables the same name as any function your package.
+Here is the current logic. Find all identifiers that:
+ - are to the right of an equal sign.
+     - `log = logWarning`
+ - are to the right of an open parentheses.
+     - `setCallback(logWarning)`
+ - are to the right of a `print` statement
+     - `print logWarning`
+ - are to the right or left of a square brace.
+     - `someObject[logWarning]`
+ - are surrounded by commas
+     - `doSomething("param1", logWarning, "param3")`
+ - are to the left of a closing parentheses
+     - `performActionWithCallback("actionName", logWarning)`
+ - are surrounded by parentheses
+     - `log = (logWarning)`
+
+
+### Caveats to finding function references
+Due to ambiguities in the Roku language, there is still one situation that is difficult to correctly identify without a full parser. Consider this statement:
+```BrightScript
+person = {
+    getName: getName,
+    getAge: getAge
+}
+```
+
+We want `ropm` to match on the the right-hand-side of both property assignments (`getName` and `getAge`). However, we can also write that statement like this:
+```BrightScript
+person = {
+    getName: getName : getAge : getAge
+}
+```
+
+This is valid BrightScript, but without a parser it's impossible for `ropm` to pick the right identifiers. We could very easily pick the object key, which would cause runtime errors on a Roku device. 
+
+For this reason, `ropm` will _NOT_ prefix function references preceed with a colon. Instead, we provide a workaround: 
+ > `ropm` will match on any identifier wrapped with parenthese. 
+
+Here's how you can safely use function references with this situation:
+```BrightScript
+person = {
+    getName: (getNameFunc),
+    getAge: (getAgeFunc)
+}
+```
+### Finding function references is a package-wide operation
+> *HINT:* do not give local variables the same name as any function in your package
+
+Identifier replacement is package-wide and does not operate on a per-scope basis, meaning `ropm` will prefix any local variable that shares a name with any function across your entire package. While the code will still run, it might appear strange to see `ropm`-specific prefixes on local variables, so we recommend that you do not give local variables the same name as any function your package.
 
 
 ## rootDir versus packageRootDir

--- a/src/TestHelpers.spec.ts
+++ b/src/TestHelpers.spec.ts
@@ -4,7 +4,7 @@ import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 import { RopmModule } from './prefixer/RopmModule';
 import { RopmOptions } from './util';
-
+import * as rokuDeploy from 'roku-deploy';
 export const sinon = createSandbox();
 
 export const tempDir = path.join(process.cwd(), '.tmp');
@@ -156,3 +156,17 @@ export async function expectThrowsAsync(func, startingText?: string) {
         throw new Error(`Expected error message '${ex.message}' to start with '${startingText}'`);
     }
 }
+
+/**
+ * A tagged template literal function for standardizing the path.
+ */
+export function standardizePath(stringParts, ...expressions: any[]) {
+    const result = [] as string[];
+    for (let i = 0; i < stringParts.length; i++) {
+        result.push(stringParts[i], expressions[i]);
+    }
+    return rokuDeploy.standardizePath(
+        result.join('')
+    );
+}
+

--- a/src/TestHelpers.spec.ts
+++ b/src/TestHelpers.spec.ts
@@ -3,6 +3,7 @@ import * as fsExtra from 'fs-extra';
 import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 import { RopmModule } from './prefixer/RopmModule';
+import { RopmOptions } from './util';
 
 export const sinon = createSandbox();
 
@@ -100,11 +101,7 @@ export interface DepGraphNode {
     version?: string;
     dependencies?: Array<DepGraphNode>;
     _files?: { [relativePath: string]: string };
-    ropm?: {
-        rootDir?: string;
-        packageRootDir?: string;
-        noprefix?: string[];
-    };
+    ropm?: RopmOptions;
 }
 
 

--- a/src/commands/CopyCommand.ts
+++ b/src/commands/CopyCommand.ts
@@ -2,7 +2,7 @@ import { InstallCommand } from './InstallCommand';
 
 export class CopyCommand {
     constructor(
-        public args: InitCommandArgs
+        public args: CopyCommandArgs
     ) {
 
     }
@@ -13,7 +13,7 @@ export class CopyCommand {
     }
 }
 
-export interface InitCommandArgs {
+export interface CopyCommandArgs {
     /**
      * The current working directory for the command.
      */

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { util } from '../util';
+import * as fsExtra from 'fs-extra';
 
 export class InitCommand {
     constructor(
@@ -9,6 +10,9 @@ export class InitCommand {
     }
 
     public async run() {
+        if (await fsExtra.pathExists(this.cwd) === false) {
+            throw new Error(`"${this.cwd}" does not exist`);
+        }
         await util.spawnNpmAsync([
             'init',
             this.args.force === true ? '--force' : undefined

--- a/src/commands/InstallCommand.spec.ts
+++ b/src/commands/InstallCommand.spec.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { InstallCommandArgs, InstallCommand } from './InstallCommand';
 import { expect } from 'chai';
 import { RopmPackageJson } from '../util';
-import { fsEqual, tempDir } from '../TestHelpers.spec';
+import { createProjects, fsEqual, standardizePath as s, tempDir } from '../TestHelpers.spec';
 
 const projectName = 'test-project';
 const projectDir = path.join(tempDir, projectName);
@@ -282,6 +282,81 @@ describe('InstallCommand', () => {
             sub rokulogger_log()
             end sub
         `);
+    });
+
+    describe('getProdDependencies', () => {
+        it('excludes dependencies in folders above cwd for command', () => {
+            const [level1, level2, level3] = createProjects(projectDir, projectDir, {
+                name: projectName,
+                dependencies: [{
+                    name: 'level1',
+                    dependencies: [{
+                        name: 'level2',
+                        dependencies: [{
+                            name: 'level3'
+                        }]
+                    }]
+                }]
+            });
+
+            expect(command.getProdDependencies().sort()).to.eql([
+                projectDir,
+                s`${projectDir}/node_modules/level1`,
+                s`${projectDir}/node_modules/level1/node_modules/level2`,
+                s`${projectDir}/node_modules/level1/node_modules/level2/node_modules/level3`
+            ]);
+
+            command = new InstallCommand({ cwd: level1.moduleDir });
+            expect(command.getProdDependencies().sort()).to.eql([
+                s`${projectDir}/node_modules/level1`,
+                s`${projectDir}/node_modules/level1/node_modules/level2`,
+                s`${projectDir}/node_modules/level1/node_modules/level2/node_modules/level3`
+            ]);
+
+            command = new InstallCommand({ cwd: level2.moduleDir });
+            expect(command.getProdDependencies().sort()).to.eql([
+                s`${projectDir}/node_modules/level1/node_modules/level2`,
+                s`${projectDir}/node_modules/level1/node_modules/level2/node_modules/level3`
+            ]);
+
+            command = new InstallCommand({ cwd: level3.moduleDir });
+            expect(command.getProdDependencies().sort()).to.eql([
+                s`${projectDir}/node_modules/level1/node_modules/level2/node_modules/level3`
+            ]);
+        });
+
+        it('excludes dependencies in folders above cwd for command', async () => {
+            //create a root project, with a dependency
+            createProjects(s`${tempDir}/outerProject`, s`${tempDir}/outerProject`, {
+                name: 'outerProject',
+                dependencies: [{
+                    name: 'outerProjectDependency'
+                }]
+            });
+
+            //create a folder inside of root project
+            createProjects(s`${tempDir}/outerProject/innerProject`, s`${tempDir}/outerProject/innerProject`, {
+                name: 'innerProject',
+                dependencies: [{
+                    name: 'innerProjectDependency'
+                }]
+            });
+
+            //install outer project
+            command.args.cwd = s`${tempDir}/outerProject`;
+            await command.run();
+
+            const innerCommand = new InstallCommand({
+                cwd: s`${tempDir}/outerProject/innerProject`
+            });
+            await innerCommand.run();
+
+            //innerProject should not list outerProject dependencies
+            expect(innerCommand.getProdDependencies().sort()).to.eql([
+                s`${tempDir}/outerProject/innerProject`,
+                s`${tempDir}/outerProject/innerProject/node_modules/innerProjectDependency`
+            ]);
+        });
     });
 });
 

--- a/src/commands/InstallCommand.spec.ts
+++ b/src/commands/InstallCommand.spec.ts
@@ -141,6 +141,33 @@ describe('InstallCommand', () => {
             )).to.be.true;
         });
 
+        it('uses module directory when `packageRootDir` is omitted', async () => {
+            writeProject('logger', {
+                'source/logger.brs': '',
+                'source/temp.brs': ''
+            });
+
+            writeProject(projectName, {
+                'src/source/main.brs': ''
+            }, {
+                dependencies: {
+                    'logger': `file:../logger`
+                },
+                ropm: {
+                    rootDir: 'src'
+                }
+            });
+
+            await command.run();
+
+            expect(fsExtra.pathExistsSync(
+                path.join(projectDir, 'src', 'source', 'roku_modules', 'logger', 'logger.brs')
+            )).to.be.true;
+            expect(fsExtra.pathExistsSync(
+                path.join(projectDir, 'src', 'source', 'roku_modules', 'logger', 'temp.brs')
+            )).to.be.true;
+        });
+
         it('works when not passing in any packages', async () => {
             //remove packages
             delete args.packages;

--- a/src/commands/InstallCommand.ts
+++ b/src/commands/InstallCommand.ts
@@ -68,6 +68,9 @@ export class InstallCommand {
     }
 
     private async npmInstall() {
+        if (await fsExtra.pathExists(this.cwd) === false) {
+            throw new Error(`"${this.cwd}" does not exist`);
+        }
         await util.spawnNpmAsync([
             'i',
             ...(this.args.packages ?? [])
@@ -102,7 +105,10 @@ export class InstallCommand {
      * This is run sync because it should run as fast as possible
      * and won't be run in ~parallel.
      */
-    getProdDependencies() {
+    public getProdDependencies() {
+        if (fsExtra.pathExistsSync(this.cwd) === false) {
+            throw new Error(`"${this.cwd}" does not exist`);
+        }
         let stdout: string;
         try {
             stdout = childProcess.execSync('npm ls --parseable --prod', {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,0 @@
-export * from './util';
-export * from './commands/InitCommand';
-export * from './commands/InstallCommand';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,6 @@
+export * from './util';
+export * from './commands/CleanCommand';
+export * from './commands/CopyCommand';
+export * from './commands/InitCommand';
+export * from './commands/InstallCommand';
+export * from './commands/UninstallCommand';

--- a/src/prefixer/File.spec.ts
+++ b/src/prefixer/File.spec.ts
@@ -49,7 +49,7 @@ describe('prefixer/File', () => {
     beforeEach(() => {
         fsExtra.ensureDirSync(tmpDir);
         fsExtra.emptyDirSync(tmpDir);
-        file = new File(srcPath, destPath, srcRootDir, { prefixMatching: 'strict' });
+        file = new File(srcPath, destPath, srcRootDir, { functionReferenceMatching: 'strict' });
         f = file;
         sinon.stub(fsExtra, 'readFile').callsFake(() => {
             return Promise.resolve(Buffer.from(fileContents));
@@ -158,7 +158,7 @@ describe('prefixer/File', () => {
                     print "hello" + " world " + name
                 end sub
             `, 'brs');
-            file.options.prefixMatching = 'expanded';
+            file.options.functionReferenceMatching = 'expanded';
             await file.discover();
             expect(file.strings).to.eql([{
                 startOffset: getOffset(2, 27),
@@ -193,7 +193,7 @@ describe('prefixer/File', () => {
                 sub log(message)
                 end sub
             `, 'brs');
-            file.options.prefixMatching = 'expanded';
+            file.options.functionReferenceMatching = 'expanded';
             await file.discover();
             expect(file.identifiers).to.eql([{
                 name: 'logVar',
@@ -213,7 +213,7 @@ describe('prefixer/File', () => {
                     print "main function"
                 end function
             `, 'brs');
-            file.options.prefixMatching = 'expanded';
+            file.options.functionReferenceMatching = 'expanded';
 
             await file.discover();
             expect(file.identifiers).to.be.empty;

--- a/src/prefixer/File.ts
+++ b/src/prefixer/File.ts
@@ -149,8 +149,8 @@ export class File {
             this.findFunctionDefinitions();
             this.findFunctionCalls();
 
-            //only search for strings and identifiers if prefixMatching is set to "expanded"
-            if (this.options.prefixMatching === 'expanded') {
+            //only search for strings and identifiers if functionReferenceMatching is set to "expanded"
+            if (this.options.functionReferenceMatching === 'expanded') {
                 this.findStrings();
                 this.findIdentifiers();
             }

--- a/src/prefixer/ModuleManager.spec.ts
+++ b/src/prefixer/ModuleManager.spec.ts
@@ -445,7 +445,7 @@ describe('ModuleManager', () => {
             await createDependencies([{
                 name: 'logger',
                 ropm: {
-                    prefixMatching: 'expanded'
+                    functionReferenceMatching: 'expanded'
                 },
                 _files: {
                     'source/lib.brs': `

--- a/src/prefixer/ModuleManager.spec.ts
+++ b/src/prefixer/ModuleManager.spec.ts
@@ -441,6 +441,36 @@ describe('ModuleManager', () => {
             `);
         });
 
+        it('applies prefix when in expanded mode', async () => {
+            await createDependencies([{
+                name: 'logger',
+                ropm: {
+                    prefixMatching: 'expanded'
+                },
+                _files: {
+                    'source/lib.brs': `
+                        sub writeToLog(message)
+                            logFunc = logWarning
+                            logFunc(message)
+                        end sub
+                        sub logWarning(message)
+                            print message
+                        end sub
+                    `
+                }
+            }]);
+            await process();
+            fsEqual(`${hostDir}/source/roku_modules/logger/lib.brs`, `
+                sub logger_writeToLog(message)
+                    logFunc = logger_logWarning
+                    logFunc(message)
+                end sub
+                sub logger_logWarning(message)
+                    print message
+                end sub
+            `);
+        });
+
         it('only prefixes calls to known own functions', async () => {
             await createDependencies([{
                 name: 'logger',

--- a/src/prefixer/ModuleManager.spec.ts
+++ b/src/prefixer/ModuleManager.spec.ts
@@ -444,9 +444,6 @@ describe('ModuleManager', () => {
         it('applies prefix when in expanded mode', async () => {
             await createDependencies([{
                 name: 'logger',
-                ropm: {
-                    functionReferenceMatching: 'expanded'
-                },
                 _files: {
                     'source/lib.brs': `
                         sub writeToLog(message)

--- a/src/prefixer/RopmModule.ts
+++ b/src/prefixer/RopmModule.ts
@@ -201,7 +201,7 @@ export class RopmModule {
         //load all files
         for (const obj of this.fileMaps) {
             this.files.push(
-                new File(obj.src, obj.dest, this.packageRootDir, this.packageJson.ropm ?? { prefixMatching: 'strict' })
+                new File(obj.src, obj.dest, this.packageRootDir, this.packageJson.ropm ?? { functionReferenceMatching: 'strict' })
             );
         }
 
@@ -311,7 +311,7 @@ export class RopmModule {
             }
 
             //if expanded mode, prefix all identifiers that have the same name as a function
-            if (applyOwnPrefix && this.packageJson.ropm?.prefixMatching === 'expanded') {
+            if (applyOwnPrefix && this.packageJson.ropm?.functionReferenceMatching === 'expanded') {
                 for (const identifier of file.identifiers) {
                     //if this identifier has the same name as a function, then prefix the identifier
                     if (ownFunctionMap[identifier.name.toLowerCase()]) {

--- a/src/prefixer/RopmModule.ts
+++ b/src/prefixer/RopmModule.ts
@@ -201,7 +201,7 @@ export class RopmModule {
         //load all files
         for (const obj of this.fileMaps) {
             this.files.push(
-                new File(obj.src, obj.dest, this.packageRootDir, this.packageJson.ropm ?? { functionReferenceMatching: 'strict' })
+                new File(obj.src, obj.dest, this.packageRootDir, this.packageJson.ropm)
             );
         }
 
@@ -310,13 +310,11 @@ export class RopmModule {
                 }
             }
 
-            //if expanded mode, prefix all identifiers that have the same name as a function
-            if (applyOwnPrefix && this.packageJson.ropm?.functionReferenceMatching === 'expanded') {
-                for (const identifier of file.identifiers) {
-                    //if this identifier has the same name as a function, then prefix the identifier
-                    if (ownFunctionMap[identifier.name.toLowerCase()]) {
-                        file.addEdit(identifier.offset, identifier.offset, prefix);
-                    }
+            //prefix all identifiers that have the same name as a function
+            for (const identifier of file.identifiers) {
+                //if this identifier has the same name as a function, then prefix the identifier
+                if (ownFunctionMap[identifier.name.toLowerCase()]) {
+                    file.addEdit(identifier.offset, identifier.offset, prefix);
                 }
             }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -251,21 +251,28 @@ export interface RopmPackageJson {
     files?: string[];
     keywords?: string[];
     version: string;
-    ropm?: {
-        /**
-         * The path to the rootDir of the project where `ropm` should install all ropm modules
-         */
-        rootDir?: string;
-        /**
-         * The path to the rootDir of the a ropm module's package files. Use this if your module stores files in a subdirectory.
-         * NOTE: This should only be used by ropm package AUTHORS
-         */
-        packageRootDir?: string;
-        /**
-         * An array of module aliases that should not be prefixed when installed into `rootDir`. Use this with caution.
-         */
-        noprefix?: string[];
-    };
+    ropm?: RopmOptions;
+}
+export interface RopmOptions {
+    /**
+     * The path to the rootDir of the project where `ropm` should install all ropm modules
+     */
+    rootDir?: string;
+    /**
+     * The path to the rootDir of the a ropm module's package files. Use this if your module stores files in a subdirectory.
+     * NOTE: This should only be used by ropm package AUTHORS
+     */
+    packageRootDir?: string;
+    /**
+     * An array of module aliases that should not be prefixed when installed into `rootDir`. Use this with caution.
+     */
+    noprefix?: string[];
+    /**
+     * If "strict", then only function calls and function declarations will be prefixed.
+     * If "expanded", in addition to the "strict" actions, ropm will also prefix any variable names that match known function names. =
+     * This slows down ropm, which is why it's hidden behind an option
+     */
+    prefixMatching?: 'strict' | 'expanded';
 }
 
 export interface ModuleDependency {

--- a/src/util.ts
+++ b/src/util.ts
@@ -267,12 +267,6 @@ export interface RopmOptions {
      * An array of module aliases that should not be prefixed when installed into `rootDir`. Use this with caution.
      */
     noprefix?: string[];
-    /**
-     * If "strict", then only function calls and function declarations will be prefixed.
-     * If "expanded", in addition to the "strict" actions, ropm will also prefix any variable names that match known function names.
-     * This slows down ropm, which is why it's hidden behind an option
-     */
-    functionReferenceMatching?: 'strict' | 'expanded';
 }
 
 export interface ModuleDependency {

--- a/src/util.ts
+++ b/src/util.ts
@@ -269,10 +269,10 @@ export interface RopmOptions {
     noprefix?: string[];
     /**
      * If "strict", then only function calls and function declarations will be prefixed.
-     * If "expanded", in addition to the "strict" actions, ropm will also prefix any variable names that match known function names. =
+     * If "expanded", in addition to the "strict" actions, ropm will also prefix any variable names that match known function names.
      * This slows down ropm, which is why it's hidden behind an option
      */
-    prefixMatching?: 'strict' | 'expanded';
+    functionReferenceMatching?: 'strict' | 'expanded';
 }
 
 export interface ModuleDependency {


### PR DESCRIPTION
This PR adds support for finding and prefixing function references in ropm modules. Function references are when you use the name of a function, but don't call that function. Function references don't have an opening parentheses, making them harder to detect.