### PR TITLE
Use brighterscript parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,7 @@ Here is some overview information to help `ropm` package authors get started:
  - `ropm` modules are simply [npm](https://www.npmjs.com/) packages with the `ropm` keyword (see [How to create a ropm package](#how-to-create-a-ropm-package))
  - Follow semantic versioning **strictly**. Make major breaking changes as infrequently as possible. (see [Semantic Versioning](#semantic-versioning))
  - `ropm` rewrites every `pkg:/` path, so use string concatenation if you need to bypass this logic (see [File paths](#file-paths))
- - Don't give local variables the same names as functions in your package. (See [Finding function references](#finding-function-references))
- - Wrap function references in parentheses to help `ropm` find them in your code (See [Finding function references: Caveats](#caveats))
+ - Don't give local variables the same names as functions in your package. (See [Finding function references](#finding-function-references-is-a-package-wide-operation))
  - Don't write BrightScript in XML `CDATA` blocks (See [BrightScript in XML CDATA blocks is unsupported](#brightScript-in-xml-cdata-blocks-is-unsupported))
  - Don't define a baseline namespace. On install, `ropm` will prefix your package for you. (See [Prefixes](#prefixes))
  -  use the `ropm` options in `package.json` to customize various settings in your package
@@ -410,70 +409,10 @@ Here's an example (**NOTE:** comments are included here for explanation purposes
 }
 ```
 
-## Finding function references
-`ropm` is very efficient at at finding function definitions and function calls. However, it's more difficult to find function references when the function is not part of a function call. For example, the `logWarning` function is being assigned by its name reference on line #2`: 
-```BrightScript
-1 | sub writeToLog(message)
-2 |     log = logWarning
-3 |     log(message);
-4 | end sub
-5 | 
-6 | sub logWarning(message)
-7 |     print "warning: " + message
-8 | end sub
-```
-
-`ropm` will smartly scan all of your package's BrightScript files for [identifiers](http://developer.roku.com/docs/references/brightscript/language/expressions-variables-types.md#identifiers) that might be function references. Then, ropm will add prefixes to all identifiers that have the same name as functions in your package. 
-
-Here is the current logic. Find all identifiers that:
- - are to the right of an equal sign.
-     - `log = logWarning`
- - are to the right of an open parentheses.
-     - `setCallback(logWarning)`
- - are to the right of a `print` statement
-     - `print logWarning`
- - are to the right or left of a square brace.
-     - `someObject[logWarning]`
- - are surrounded by commas
-     - `doSomething("param1", logWarning, "param3")`
- - are to the left of a closing parentheses
-     - `performActionWithCallback("actionName", logWarning)`
- - are surrounded by parentheses (more on this below)
-     - `log = (logWarning)`
-
-
-### Caveats to finding function references
-Due to ambiguities in the BrightScript language, there is still one situation that is difficult to correctly identify without a full parser. Consider this statement:
-```BrightScript
-person = {
-    getName: getName,
-    getAge: getAge
-}
-```
-
-We want `ropm` to match on the the right-hand-side of both property assignments (`getName` and `getAge`). However, we can also write that statement like this:
-```BrightScript
-person = {
-    getName: getName : getAge : getAge
-}
-```
-
-This is valid BrightScript, but without a parser it's impossible for `ropm` to pick the right identifiers. We could very easily pick the object key, which would cause runtime errors on a Roku device. 
-
-For this reason, `ropm` will _NOT_ prefix function references preceed with a colon. Instead, we provide a workaround: 
- > `ropm` will match on any identifier wrapped with parenthese. 
-
-Here's how you can safely use function references with this situation:
-```BrightScript
-person = {
-    getName: (getName),
-    getAge: (getAge)
-}
-```
 ### Finding function references is a package-wide operation
 > *HINT:* do not give local variables the same name as any function in your package
 
-Identifier replacement is package-wide and does not operate on a per-scope basis, meaning `ropm` will prefix any local variable that shares a name with any function across your entire package. While the code will still run, it might appear strange to see `ropm`-specific prefixes on local variables, so we recommend that you do not give local variables the same name as any function your package.
+Function reference replacement is package-wide and does not operate on a per-scope basis, meaning `ropm` could add prefixes to local variables that share a name with any function across your entire package. We recommend that you do not give local variables the same name as any function your package.
 
 
 ## rootDir versus packageRootDir

--- a/package-lock.json
+++ b/package-lock.json
@@ -435,7 +435,6 @@
       "version": "15.0.5",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
       "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -443,8 +442,7 @@
     "@types/yargs-parser": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
-      "dev": true
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "3.6.0",
@@ -604,7 +602,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -613,7 +610,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
       "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -706,6 +702,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw=="
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -797,8 +798,7 @@
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-      "dev": true
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
     "bl": {
       "version": "4.0.3",
@@ -825,6 +825,95 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "brighterscript": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.16.1.tgz",
+      "integrity": "sha512-18L3fayPV0ojkIvz0L+cuvqHZAaOzpUmCdV5+DyuRXFzJ0hCiLN6CthQDORVDAK/eMjwj52MtZMr1MTg95gxOQ==",
+      "requires": {
+        "@types/yargs": "^15.0.5",
+        "array-flat-polyfill": "^1.0.1",
+        "chalk": "^2.4.2",
+        "chokidar": "^3.0.2",
+        "clear": "^0.1.0",
+        "cross-platform-clear-console": "^2.3.0",
+        "debounce-promise": "^3.1.0",
+        "eventemitter3": "^4.0.0",
+        "file-url": "^3.0.0",
+        "fs-extra": "^7.0.1",
+        "glob": "^7.1.6",
+        "jsonc-parser": "^2.3.0",
+        "long": "^3.2.0",
+        "luxon": "^1.8.3",
+        "minimatch": "^3.0.4",
+        "moment": "^2.23.0",
+        "p-settle": "^2.1.0",
+        "parse-ms": "^2.1.0",
+        "roku-deploy": "^3.2.3",
+        "serialize-error": "^7.0.1",
+        "source-map": "^0.7.3",
+        "vscode-languageserver": "^6.1.1",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-uri": "^2.1.1",
+        "xml2js": "^0.4.19",
+        "yargs": "^15.4.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "roku-deploy": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.2.3.tgz",
+          "integrity": "sha512-4h3yDAQl7uHzVjvu4XtvQJOYeKfBBhWcM3ss46RVT8HqYZdMJ5+kVP2+oPymA3U3pzGvtoSI/OuM0JG/VSNyGg==",
+          "requires": {
+            "archiver": "^3.0.0",
+            "dateformat": "^3.0.3",
+            "fs-extra": "^7.0.1",
+            "glob": "^7.1.6",
+            "jsonc-parser": "^2.3.0",
+            "minimatch": "^3.0.4",
+            "path": "^0.12.7",
+            "request": "^2.88.0",
+            "xml2js": "^0.4.23"
+          }
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
       }
     },
     "browser-stdout": {
@@ -965,7 +1054,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
       "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
-      "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -981,6 +1069,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+    },
+    "clear": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clear/-/clear-0.1.0.tgz",
+      "integrity": "sha512-qMjRnoL+JDPJHeLePZJuao6+8orzHMGP04A8CdwCNsKhRbOnKRjefxONR7bwILT3MHecxKBjHkKL/tkZ8r4Uzw=="
     },
     "cliui": {
       "version": "6.0.0",
@@ -1018,7 +1111,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1026,8 +1118,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1137,6 +1228,11 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "cross-platform-clear-console": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cross-platform-clear-console/-/cross-platform-clear-console-2.3.0.tgz",
+      "integrity": "sha512-To+sJ6plHHC6k5DfdvSVn6F1GRGJh/R6p76bCpLbyMyHEmbqFyuMAeGwDcz/nGDWH3HUcjFTTX9iUSCzCg9Eiw=="
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1160,6 +1256,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+    },
+    "debounce-promise": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.1.2.tgz",
+      "integrity": "sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg=="
     },
     "debug": {
       "version": "4.1.1",
@@ -1353,8 +1454,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "7.7.0",
@@ -1486,6 +1586,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1541,6 +1646,11 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/file-url/-/file-url-3.0.0.tgz",
+      "integrity": "sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -1652,7 +1762,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -1796,8 +1905,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -1901,7 +2009,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -2389,6 +2496,16 @@
         }
       }
     },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+    },
+    "luxon": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
+      "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -2638,6 +2755,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2828,6 +2950,35 @@
         "aggregate-error": "^3.0.0"
       }
     },
+    "p-reflect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-1.0.0.tgz",
+      "integrity": "sha1-9Poe4btUbY6z7AMhFI3+CnkTe7g="
+    },
+    "p-settle": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-2.1.0.tgz",
+      "integrity": "sha512-NHFIUYc+fQTFRrzzAugq0l1drwi57PB522smetcY8C/EoTYs6cU/fC6TJj0N3rq5NhhJJbhf0VGWziL3jZDnjA==",
+      "requires": {
+        "p-limit": "^1.2.0",
+        "p-reflect": "^1.0.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        }
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -2853,6 +3004,11 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="
     },
     "path": {
       "version": "0.12.7",
@@ -3014,7 +3170,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
       "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
-      "dev": true,
       "requires": {
         "picomatch": "^2.0.7"
       }
@@ -3170,6 +3325,21 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
       "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+    },
+    "serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "requires": {
+        "type-fest": "^0.13.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
+        }
+      }
     },
     "serialize-javascript": {
       "version": "4.0.0",
@@ -3412,7 +3582,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -3611,6 +3780,43 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vscode-jsonrpc": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+    },
+    "vscode-languageserver": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz",
+      "integrity": "sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==",
+      "requires": {
+        "vscode-languageserver-protocol": "^3.15.3"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+      "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
+      "requires": {
+        "vscode-jsonrpc": "^5.0.1",
+        "vscode-languageserver-types": "3.15.1"
+      }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
+    },
+    "vscode-languageserver-types": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+      "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
+    },
+    "vscode-uri": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+      "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/semver": "^7.3.1",
     "@xml-tools/ast": "^5.0.0",
     "@xml-tools/parser": "^1.0.7",
+    "brighterscript": "^0.16.1",
     "del": "^5.1.0",
     "fs-extra": "^9.0.1",
     "glob-all": "^3.2.1",

--- a/src/prefixer/File.spec.ts
+++ b/src/prefixer/File.spec.ts
@@ -4,11 +4,12 @@ import * as path from 'path';
 import * as fsExtra from 'fs-extra';
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';
+import { Program } from 'brighterscript';
 const sinon = createSandbox();
 
 const tmpDir = path.join(process.cwd(), '.tmp');
-const srcRootDir = path.join(tmpDir, 'srcRootDir');
-const srcPath = path.join(srcRootDir, 'source', 'file.brs');
+const rootDir = path.join(tmpDir, 'srcRootDir');
+const srcPath = path.join(rootDir, 'components', 'file.brs');
 const destPath = path.join(tmpDir, 'dest', 'file.brs');
 
 describe('prefixer/File', () => {
@@ -16,15 +17,40 @@ describe('prefixer/File', () => {
     let file: File;
     let f: any;
     let fileContents = '';
+    let program: Program;
+
+    beforeEach(() => {
+        fsExtra.ensureDirSync(tmpDir);
+        fsExtra.emptyDirSync(tmpDir);
+        file = new File(srcPath, destPath, rootDir);
+        f = file;
+        sinon.stub(fsExtra, 'readFile').callsFake(() => {
+            return Promise.resolve(Buffer.from(fileContents));
+        });
+        program = new Program({
+            rootDir: rootDir
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
 
     /**
      * Set the contents of the file right before a test.
      * This also normalizes line endings to `\n` to make the tests consistent
      */
-    function setFile(value: string, extension = 'brs') {
+    async function setFile(value: string, extension: 'brs' | 'xml' = 'brs') {
         fileContents = value.replace(/\r\n/, '\n');
-        f.src = f.src.replace('.brs', '.' + extension);
-        f.dest = f.dest.replace('.brs', '.' + extension);
+        file.srcPath = f.srcPath.replace('.brs', '.' + extension);
+        file.destPath = f.destPath.replace('.brs', '.' + extension);
+        const relativeSrcPath = f.srcPath
+            //make path relative
+            .replace(rootDir, '')
+            //remove leading slashes
+            .replace(/^(\/|\\)*/, '');
+        await program.addOrReplaceFile(relativeSrcPath, fileContents);
     }
 
     /**
@@ -68,61 +94,28 @@ describe('prefixer/File', () => {
         }
     }
 
-    beforeEach(() => {
-        fsExtra.ensureDirSync(tmpDir);
-        fsExtra.emptyDirSync(tmpDir);
-        file = new File(srcPath, destPath, srcRootDir);
-        f = file;
-        sinon.stub(fsExtra, 'readFile').callsFake(() => {
-            return Promise.resolve(Buffer.from(fileContents));
-        });
-    });
-    afterEach(() => {
-        sinon.restore();
-    });
-
-    it('loads file from disk', async () => {
-        sinon.restore();
-        fsExtra.ensureDirSync(path.dirname(destPath));
-        fsExtra.writeFileSync(destPath, 'asdf');
-        await file.discover();
-        expect((f.fileContents)).to.eql('asdf');
-    });
-
     describe('findFunctionDefinitions', () => {
         it('finds functions in multiple lines', async () => {
-            setFile(`
+            await setFile(`
                 function Main()
+                end function
                 function Main2()
+                end function
             `);
-            await file.discover();
+            file.discover(program);
             expect(f.functionDefinitions).to.eql([{
                 name: 'Main',
                 offset: getOffset(1, 25)
             }, {
                 name: 'Main2',
-                offset: getOffset(2, 25)
-            }]);
-        });
-
-        it('finds multiple functions on a line (probably not possible, but why not...)', async () => {
-            setFile(`
-                function Main() function Main2()
-            `);
-            await file.discover();
-            expect(f.functionDefinitions).to.eql([{
-                name: 'Main',
-                offset: getOffset(1, 25)
-            }, {
-                name: 'Main2',
-                offset: getOffset(1, 41)
+                offset: getOffset(3, 25)
             }]);
         });
     });
 
     describe('findFunctionCalls', () => {
         it('works for brs files', async () => {
-            setFile(`
+            await setFile(`
                 'should not match on "main"
                 sub main()
                     doSomething()
@@ -132,7 +125,7 @@ describe('prefixer/File', () => {
                     end function
                 end sub
             `);
-            await file.discover();
+            file.discover(program);
             expect(f.functionCalls).to.eql([{
                 name: 'doSomething',
                 offset: getOffset(3, 20)
@@ -143,7 +136,7 @@ describe('prefixer/File', () => {
         });
 
         it('does not match object function calls', async () => {
-            setFile(`
+            await setFile(`
                 sub getPerson()
                     person = {
                         speak: sub(message)
@@ -161,7 +154,7 @@ describe('prefixer/File', () => {
                     print message
                 end sub
             `, 'brs');
-            await file.discover();
+            file.discover(program);
             expect(f.functionCalls).to.eql([{
                 name: 'speak',
                 offset: getOffset(8, 28)
@@ -174,13 +167,13 @@ describe('prefixer/File', () => {
 
     describe('findStrings', () => {
         it('finds all strings in the file', async () => {
-            setFile(`
+            await setFile(`
                 sub main()
                     name = "bob"
                     print "hello" + " world " + name
                 end sub
             `, 'brs');
-            await file.discover();
+            file.discover(program);
             expect(file.strings).to.eql([{
                 startOffset: getOffset(2, 27),
                 endOffset: getOffset(2, 32)
@@ -194,11 +187,11 @@ describe('prefixer/File', () => {
         });
 
         it('only scans brightscript files', async () => {
-            setFile(`<?xml version="1.0" encoding="utf-8" ?>
+            await setFile(`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="CustomComponent">
                 </component>
             `, 'xml');
-            await file.discover();
+            file.discover(program);
             expect(file.strings).to.be.empty;
         });
     });
@@ -206,9 +199,9 @@ describe('prefixer/File', () => {
     describe('findIdentifiers', () => {
         it('works for regex test case', async () => {
             async function verifyIdentifier(text: string, ...expectedIdentifiers: [string, number, number][]) {
-                setFile(text);
-                file = new File(srcPath, destPath, srcRootDir);
-                await file.discover();
+                await setFile(text);
+                file = new File(srcPath, destPath, rootDir);
+                file.discover(program);
 
                 const identifiers = [] as { name: string; line: number; character: number }[];
                 for (const identifier of expectedIdentifiers) {
@@ -271,7 +264,7 @@ describe('prefixer/File', () => {
         });
 
         it('finds various identifiers', async () => {
-            setFile(`
+            await setFile(`
                 function main()
                     logVar = log
                     logVar("logVar")
@@ -280,7 +273,7 @@ describe('prefixer/File', () => {
                 sub log(message)
                 end sub
             `, 'brs');
-            await file.discover();
+            file.discover(program);
             expect(file.identifiers).to.eql([{
                 name: 'log',
                 offset: getOffset(2, 29)
@@ -291,24 +284,24 @@ describe('prefixer/File', () => {
         });
 
         it('skips identifiers in strings and keyword identifiers', async () => {
-            setFile(`
+            await setFile(`
                 function main()
                     print "main function"
                 end function
             `, 'brs');
 
-            await file.discover();
+            file.discover(program);
             expect(file.identifiers).to.be.empty;
         });
     });
 
     describe('findComponentDefinitions', () => {
         it('finds component name', async () => {
-            setFile(`<?xml version="1.0" encoding="utf-8" ?>
+            await setFile(`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="CustomComponent">
                 </component>
             `, 'xml');
-            await file.discover();
+            file.discover(program);
             expect(f.componentDeclarations).to.eql([{
                 name: 'CustomComponent',
                 offset: getOffset(1, 33)
@@ -318,11 +311,11 @@ describe('prefixer/File', () => {
 
     describe('findComponentReferences', () => {
         it('finds component name from `extends` attribute', async () => {
-            setFile(`<?xml version="1.0" encoding="utf-8" ?>
+            await setFile(`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="CustomComponent" extends="ParentComponent" >
                 </component>
             `, 'xml');
-            await file.discover();
+            file.discover(program);
             expect(f.componentReferences).to.eql([{
                 name: 'ParentComponent',
                 offset: getOffset(1, 59)
@@ -330,7 +323,7 @@ describe('prefixer/File', () => {
         });
 
         it('finds component name in `createObject`', async () => {
-            setFile(`
+            await setFile(`
                 sub main()
                     'normal
                     createObject("RoSGNode", "Component1")
@@ -340,7 +333,7 @@ describe('prefixer/File', () => {
                     createObject("rosgnode","Component3")
                 end sub
             `);
-            await file.discover();
+            file.discover(program);
             expect(f.componentReferences).to.eql([{
                 name: 'Component1',
                 offset: getOffset(3, 46)
@@ -354,7 +347,7 @@ describe('prefixer/File', () => {
         });
 
         it('finds component name in `node.createChild`', async () => {
-            setFile(`
+            await setFile(`
                 sub main()
                     'normal
                     node.CreateChild("Component1")
@@ -374,7 +367,7 @@ describe('prefixer/File', () => {
                     node.CreateChild(getNodeName())
                 end sub
             `);
-            await file.discover();
+            file.discover(program);
             expect(f.componentReferences).to.eql([{
                 name: 'Component1',
                 offset: getOffset(3, 38)
@@ -391,7 +384,7 @@ describe('prefixer/File', () => {
         });
 
         it('finds component name in xml usage', async () => {
-            setFile(`<?xml version="1.0" encoding="utf-8" ?>
+            await setFile(`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="CustomComponent">
                     <children>
                         <CustomComponent2></CustomComponent2>
@@ -400,7 +393,7 @@ describe('prefixer/File', () => {
                     </children>
                 </component>
             `, 'xml');
-            await file.discover();
+            file.discover(program);
             expect(
                 file.componentReferences.sort((a, b) => {
                     if (a.offset > b.offset) {
@@ -428,14 +421,14 @@ describe('prefixer/File', () => {
 
     describe('findFileReferences', () => {
         it('finds absolute script paths in xml tags', async () => {
-            setFile(`<?xml version="1.0" encoding="utf-8" ?>
+            await setFile(`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="CustomComponent">
                     <script uri="pkg:/source/lib.brs" />
                     <script uri="pkg:/components/folder1/somelib.brs" />
                     <Poster uri="pkg:/images/CoolPhoto.png" />
                 </component>
             `, 'xml');
-            await file.discover();
+            file.discover(program);
             expect(file.fileReferences).to.eql([{
                 path: 'pkg:/source/lib.brs',
                 offset: getOffset(2, 33)
@@ -449,13 +442,13 @@ describe('prefixer/File', () => {
         });
 
         it('finds relative file paths in xml script tags', async () => {
-            setFile(`<?xml version="1.0" encoding="utf-8" ?>
+            await setFile(`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="CustomComponent">
                     <script uri="../lib.brs" />
                     <script uri="comp.brs" />
                 </component>
-            `, 'file.xml');
-            await file.discover();
+            `, 'xml');
+            file.discover(program);
             expect(file.fileReferences).to.eql([{
                 path: '../lib.brs',
                 offset: getOffset(2, 33)
@@ -465,32 +458,13 @@ describe('prefixer/File', () => {
             }]);
         });
 
-        it('finds absolute file paths in CDATA xml block', async () => {
-            setFile(`<?xml version="1.0" encoding="utf-8" ?>
-                <component name="CustomComponent"> 
-                    <script type="text/brightscript">
-                        <![CDATA[
-                            sub DoSomething()
-                                thePath = "pkg:/source/lib.brs"
-                            end sub
-                        ]]>
-                    </script>
-                </component>
-            `, 'xml');
-            await file.discover();
-            expect(file.fileReferences).to.eql([{
-                path: 'pkg:/source/lib.brs',
-                offset: getOffset(5, 43)
-            }]);
-        });
-
         it('finds pkg paths in brs files', async () => {
-            setFile(`
+            await setFile(`
                 sub main()
                     filePath = "pkg:/images/CoolPhoto.brs"
                 end sub
             `);
-            await file.discover();
+            file.discover(program);
             expect(file.fileReferences).to.eql([{
                 path: 'pkg:/images/CoolPhoto.brs',
                 offset: getOffset(2, 32)
@@ -498,42 +472,48 @@ describe('prefixer/File', () => {
         });
     });
     describe('applyEdits', () => {
-        it('leaves file intact with no edits', () => {
-            file.fileContents = 'hello world';
+        it('leaves file intact with no edits', async () => {
+            await setFile('hello world', 'brs');
+            file.discover(program);
             file.applyEdits();
-            expect(file.fileContents).to.equal('hello world');
+            expect(file.bscFile.fileContents).to.equal('hello world');
         });
 
-        it('applies zero-length edit as an insert', () => {
-            file.fileContents = 'hello world';
+        it('applies zero-length edit as an insert', async () => {
+            await setFile('hello world', 'brs');
+            file.discover(program);
             file.addEdit(5, 5, ' my');
             file.applyEdits();
-            expect(file.fileContents).to.equal('hello my world');
+            expect(file.bscFile.fileContents).to.equal('hello my world');
         });
 
-        it('removes text with zero-length edit', () => {
-            file.fileContents = 'hello world';
+        it('removes text with zero-length edit', async () => {
+            await setFile('hello world', 'brs');
+            file.discover(program);
             file.addEdit(5, 11, '');
             file.applyEdits();
-            expect(file.fileContents).to.equal('hello');
+            expect(file.bscFile.fileContents).to.equal('hello');
         });
 
-        it('replaces text', () => {
-            file.fileContents = 'hello Jim, how are you';
+        it('replaces text', async () => {
+            await setFile('hello Jim, how are you', 'brs');
+            file.discover(program);
             file.addEdit(6, 9, 'Michael');
             file.applyEdits();
-            expect(file.fileContents).to.equal('hello Michael, how are you');
+            expect(file.bscFile.fileContents).to.equal('hello Michael, how are you');
         });
 
-        it('works at beginning of string', () => {
-            file.fileContents = 'hello world';
+        it('works at beginning of string', async () => {
+            await setFile('hello world', 'brs');
+            file.discover(program);
             file.addEdit(0, 5, 'goodbye');
             file.applyEdits();
-            expect(file.fileContents).to.equal('goodbye world');
+            expect(file.bscFile.fileContents).to.equal('goodbye world');
         });
 
-        it('works with out-of-order edits', () => {
-            file.fileContents = 'one two three';
+        it('works with out-of-order edits', async () => {
+            await setFile('one two three', 'brs');
+            file.discover(program);
             //middle
             file.addEdit(4, 7, 'twelve');
             //last
@@ -542,7 +522,7 @@ describe('prefixer/File', () => {
             file.addEdit(0, 3, 'eleven');
 
             file.applyEdits();
-            expect(file.fileContents).to.equal('eleven twelve thirteen');
+            expect(file.bscFile.fileContents).to.equal('eleven twelve thirteen');
         });
     });
 });

--- a/src/prefixer/File.spec.ts
+++ b/src/prefixer/File.spec.ts
@@ -303,6 +303,19 @@ describe('prefixer/File', () => {
                 offset: getOffset(1, 33)
             }]);
         });
+
+        it('finds component name on separate line', async () => {
+            await setFile(`<?xml version="1.0" encoding="utf-8" ?>
+                <component 
+                    name="CustomComponent">
+                </component>
+            `, 'xml');
+            file.discover(program);
+            expect(f.componentDeclarations).to.eql([{
+                name: 'CustomComponent',
+                offset: getOffset(2, 26)
+            }]);
+        });
     });
 
     describe('findComponentReferences', () => {
@@ -315,6 +328,19 @@ describe('prefixer/File', () => {
             expect(f.componentReferences).to.eql([{
                 name: 'ParentComponent',
                 offset: getOffset(1, 59)
+            }]);
+        });
+
+        it('finds component name from `extends` attribute on different line', async () => {
+            await setFile(`<?xml version="1.0" encoding="utf-8" ?>
+                <component name="CustomComponent" 
+                    extends="ParentComponent" >
+                </component>
+            `, 'xml');
+            file.discover(program);
+            expect(f.componentReferences).to.eql([{
+                name: 'ParentComponent',
+                offset: getOffset(2, 29)
             }]);
         });
 

--- a/src/prefixer/File.ts
+++ b/src/prefixer/File.ts
@@ -288,12 +288,12 @@ export class File {
     }
 
     private findComponentDefinitions() {
-        //find the name of the component
-        if (isXmlFile(this.bscFile) && this.bscFile.componentName) {
+        const nameAttribute = this.xmlAst?.rootElement?.attributes?.find(x => x.key?.toLowerCase() === 'name');
+        if (nameAttribute?.value && nameAttribute?.syntax?.value) {
             this.componentDeclarations.push({
-                name: this.bscFile.componentName,
+                name: nameAttribute.value,
                 //plus one to step past the opening "
-                offset: this.rangeToOffset(this.bscFile.componentNameRange)
+                offset: nameAttribute.syntax.value.startOffset + 1
             });
         }
     }
@@ -302,11 +302,13 @@ export class File {
      * Find component names from the `extends` attribute of the `<component` element
      */
     private findExtendsComponentReferences() {
-        //find the name of the parent component
-        if (isXmlFile(this.bscFile) && this.bscFile.parentComponentName) {
+        //get any "extends" attribute from the xml
+        const extendsAttribute = this.xmlAst?.rootElement?.attributes?.find(x => x.key?.toLowerCase() === 'extends');
+        if (extendsAttribute?.value && extendsAttribute?.syntax?.value) {
             this.componentReferences.push({
-                name: this.bscFile.parentComponentName,
-                offset: this.rangeToOffset(this.bscFile.parentNameRange)
+                name: extendsAttribute.value,
+                //plus one to step past the opening "
+                offset: extendsAttribute.syntax.value.startOffset + 1
             });
         }
     }

--- a/src/prefixer/File.ts
+++ b/src/prefixer/File.ts
@@ -4,7 +4,7 @@ import * as xmlParser from '@xml-tools/parser';
 import { buildAst, XMLDocument, XMLElement } from '@xml-tools/ast';
 import { RopmOptions, util } from '../util';
 import * as path from 'path';
-import { BrsFile, createVisitor, isCallExpression, isDottedGetExpression, isDottedSetStatement, isIndexedGetExpression, isIndexedSetStatement, isXmlFile, Program, Range, WalkMode, XmlFile } from 'brighterscript';
+import { BrsFile, createVisitor, isCallExpression, isDottedGetExpression, isDottedSetStatement, isIndexedGetExpression, isIndexedSetStatement, Program, Range, WalkMode, XmlFile } from 'brighterscript';
 
 export class File {
     constructor(

--- a/src/prefixer/File.ts
+++ b/src/prefixer/File.ts
@@ -4,7 +4,7 @@ import * as xmlParser from '@xml-tools/parser';
 import { buildAst, XMLDocument, XMLElement } from '@xml-tools/ast';
 import { RopmOptions, util } from '../util';
 import * as path from 'path';
-import { BrsFile, Program, Range, XmlFile } from 'brighterscript';
+import { BrsFile, createVisitor, isCallExpression, isDottedGetExpression, isDottedSetStatement, isIndexedGetExpression, isIndexedSetStatement, Program, Range, WalkMode, XmlFile } from 'brighterscript';
 
 export class File {
     constructor(
@@ -83,23 +83,11 @@ export class File {
     }>;
 
     /**
-     * All identifiers in this file. This will definitely include more than just the actual identifiers,
-     * but we only use this list to replace known function names, so it's ok to be a little greedy here.
+     * Identifiers found in this file. We use this list to replace known function names, so it's ok to be a little greedy in our matching.
      */
     public identifiers = [] as Array<{
         name: string;
         offset: number;
-    }>;
-
-    /**
-     * An array of string offsetBegin and offsetEnd pairs that indicate where
-     * strings are located in this file.
-     *
-     * Useful when performing blanket text replacement so we don't replace inside of strings
-     */
-    public strings = [] as Array<{
-        startOffset: number;
-        endOffset: number;
     }>;
 
     private edits = [] as Edit[];
@@ -163,8 +151,6 @@ export class File {
             this.findCreateObjectComponentReferences();
             this.findCreateChildComponentReferences();
             this.findFunctionDefinitions();
-            this.findFunctionCalls();
-            this.findStrings();
             this.findIdentifiers();
             this.findObserveFieldFunctionNames();
         } else if (this.isXmlFile) {
@@ -177,136 +163,40 @@ export class File {
     }
 
     /**
-     * A binary search through the strings in this file to determine if this offset is found within the string range
-     */
-    private isOffsetWithinString(offset: number) {
-        let start = 0;
-        let end = this.strings.length - 1;
-
-        // Iterate while start not meets end
-        while (start <= end) {
-
-            // Find the mid index
-            const mid = Math.floor((start + end) / 2);
-
-            const range = this.strings[mid];
-
-            // If element is present at mid, return True
-            if (offset > range.startOffset && offset < range.endOffset) {
-                return true;
-
-                // Else look in left or right half accordingly
-            } else if (range.startOffset < offset) {
-                start = mid + 1;
-
-            } else {
-                end = mid - 1;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * A map of all the keywords in brighterscript that may not be identifiers or function names
-     */
-    private static keywordMap = {
-        and: true,
-        box: true,
-        createobject: true,
-        dim: true,
-        each: true,
-        else: true,
-        elseif: true,
-        end: true,
-        endfunction: true,
-        endif: true,
-        endsub: true,
-        endwhile: true,
-        eval: true,
-        exit: true,
-        exitwhile: true,
-        false: true,
-        for: true,
-        function: true,
-        goto: true,
-        if: true,
-        invalid: true,
-        let: true,
-        next: true,
-        not: true,
-        objfun: true,
-        or: true,
-        pos: true,
-        print: true,
-        rem: true,
-        return: true,
-        step: true,
-        sub: true,
-        tab: true,
-        then: true,
-        to: true,
-        true: true,
-        type: true,
-        while: true,
-        boolean: true,
-        string: true,
-        object: true,
-        void: true,
-        as: true,
-        in: true
-    };
-
-    /**
      * find all identifiers in this file. This will definitely find keywords and reserved words,
      * but we only use this list to replace known function names, so it's ok to be a little greedy here.
      */
     public findIdentifiers() {
-        //using negative lookbehind, so require node >=8.1.10
-        //find identifiers in the file.
-        //see the unit test for all scenarios this covers, but basically it tries to find assignments, print statements,
-        //identifiers being passed as function parameters, or identifiers wrapped in left and right parens
-        //regex test: https://regex101.com/r/LUuU8X/1
-        const regexp = /(?:(?<=(?:=|\(|\[|:|print)\s*)([a-z0-9_]+\b)(?!\.))|(?:([a-z0-9_]+)(?=\s*(?:\]|\))))|(?:(?<=,\s*)([a-z0-9_]+)(?=\s*,))/gim;
+        this.bscFile.parser.ast.walk(createVisitor({
+            /* eslint-disable @typescript-eslint/naming-convention */
+            VariableExpression: (variable, parent) => {
+                //skip objects to left of dotted/indexed expressions
+                if ((
+                    isDottedSetStatement(parent) ||
+                    isDottedGetExpression(parent) ||
+                    isIndexedSetStatement(parent) ||
+                    isIndexedGetExpression(parent)
+                ) && parent.obj === variable) {
+                    return;
+                }
 
-        let match: RegExpExecArray | null;
-
-        while (match = regexp.exec(this.bscFile.fileContents)) {
-            //the regex had to use multiple capture groups, so check if any of them have the identifier
-            const identifier = match[1] || match[2] || match[3] || match[4];
-            //don't keep this identifier if it exists within a string, or if it's a keyword
-            if (this.isOffsetWithinString(match.index) || File.keywordMap[identifier.toLowerCase()]) {
-                continue;
+                //track function calls
+                if (isCallExpression(parent) && variable === parent.callee) {
+                    this.functionCalls.push({
+                        name: variable.name.text,
+                        offset: this.rangeToOffset(variable.name.range)
+                    });
+                } else {
+                    this.identifiers.push({
+                        name: variable.name.text,
+                        offset: this.rangeToOffset(variable.name.range)
+                    });
+                }
             }
-            this.identifiers.push({
-                name: identifier,
-                offset: match.index
-            });
-        }
-    }
-
-    /**
-     * Find all of the strings in the file. Since BrightScript doesn't have an escape character,
-     * this is as simple as even-odd matching to track the string locations.
-     * Using a regexp is surprisingly faster than looping the characters directly.
-     */
-    public findStrings() {
-        this.strings = [];
-
-        const regexp = /"/g;
-        let start = null as number | null;
-        let match: RegExpExecArray | null;
-        while (match = regexp.exec(this.bscFile.fileContents)) {
-            if (start) {
-                this.strings.push({
-                    startOffset: start,
-                    endOffset: match.index + 1
-                });
-                start = null;
-            } else {
-                start = match.index;
-            }
-        }
+            /* eslint-enable @typescript-eslint/naming-convention */
+        }), {
+            walkMode: WalkMode.visitAllRecursive
+        });
     }
 
     /**
@@ -371,22 +261,6 @@ export class File {
             this.functionDefinitions.push({
                 name: func.name.text,
                 offset: this.rangeToOffset(func.name.range)
-            });
-        }
-    }
-
-    private findFunctionCalls() {
-        //using negative lookbehind, so require node >=8.1.10
-        //capture every identifier NOT preceeded by sub or function, that is not the exact text "sub" or "function"
-        const regexp = /(?<!(?:sub|function)[ \t]+)(?!function|sub\b)\b(?<!\.|\])([a-z0-9_]+)\s*\(/gi;
-
-        let match: RegExpExecArray | null;
-        while (match = regexp.exec(this.bscFile.fileContents)) {
-            const functionName = match[1];
-
-            this.functionCalls.push({
-                name: functionName,
-                offset: match.index
             });
         }
     }

--- a/src/prefixer/File.ts
+++ b/src/prefixer/File.ts
@@ -4,7 +4,7 @@ import * as xmlParser from '@xml-tools/parser';
 import { buildAst, XMLDocument, XMLElement } from '@xml-tools/ast';
 import { RopmOptions, util } from '../util';
 import * as path from 'path';
-import { BrsFile, createVisitor, isCallExpression, isDottedGetExpression, isDottedSetStatement, isIndexedGetExpression, isIndexedSetStatement, Program, Range, WalkMode, XmlFile } from 'brighterscript';
+import { BrsFile, createVisitor, isCallExpression, isDottedGetExpression, isDottedSetStatement, isIndexedGetExpression, isIndexedSetStatement, isXmlFile, Program, Range, WalkMode, XmlFile } from 'brighterscript';
 
 export class File {
     constructor(
@@ -288,12 +288,12 @@ export class File {
     }
 
     private findComponentDefinitions() {
-        const nameAttribute = this.xmlAst?.rootElement?.attributes?.find(x => x.key?.toLowerCase() === 'name');
-        if (nameAttribute?.value && nameAttribute?.syntax?.value) {
+        //find the name of the component
+        if (isXmlFile(this.bscFile) && this.bscFile.componentName) {
             this.componentDeclarations.push({
-                name: nameAttribute.value,
+                name: this.bscFile.componentName,
                 //plus one to step past the opening "
-                offset: nameAttribute.syntax.value.startOffset + 1
+                offset: this.rangeToOffset(this.bscFile.componentNameRange)
             });
         }
     }
@@ -302,13 +302,11 @@ export class File {
      * Find component names from the `extends` attribute of the `<component` element
      */
     private findExtendsComponentReferences() {
-        //get any "extends" attribute from the xml
-        const extendsAttribute = this.xmlAst?.rootElement?.attributes?.find(x => x.key?.toLowerCase() === 'extends');
-        if (extendsAttribute?.value && extendsAttribute?.syntax?.value) {
+        //find the name of the parent component
+        if (isXmlFile(this.bscFile) && this.bscFile.parentComponentName) {
             this.componentReferences.push({
-                name: extendsAttribute.value,
-                //plus one to step past the opening "
-                offset: extendsAttribute.syntax.value.startOffset + 1
+                name: this.bscFile.parentComponentName,
+                offset: this.rangeToOffset(this.bscFile.parentNameRange)
             });
         }
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,6 +5,7 @@ import * as globAll from 'glob-all';
 import * as latinize from 'latinize';
 import * as semver from 'semver';
 import { IOptions } from 'glob';
+import { Program } from 'brighterscript';
 
 export class Util {
 
@@ -257,6 +258,20 @@ export class Util {
         return count === 0;
     }
 
+    /**
+     * Replaces the Program.validate call with an empty function.
+     * This allows us to bypass BrighterScript's validation cycle, which speeds up performace
+     */
+    public mockProgramValidate() {
+        if (Program.prototype.validate !== mockProgramValidate) {
+            Program.prototype.validate = mockProgramValidate;
+        }
+    }
+
+}
+
+function mockProgramValidate() {
+    return Promise.resolve();
 }
 export const util = new Util();
 


### PR DESCRIPTION
Use the `BrighterScript` parser for better prefixing support.

**Notable changes:**
 - more accurately find function references, which removes limitations like wrapping function refs in parens (basically removed [this whole block of documentation](https://github.com/rokucommunity/ropm/tree/c46d0fbf14b0229bc57dd0c805004d84a1445302#finding-function-references) because it's no longer relevant