### PR TITLE
Don't prefix certain function references.

### DIFF
--- a/src/prefixer/ModuleManager.spec.ts
+++ b/src/prefixer/ModuleManager.spec.ts
@@ -1169,13 +1169,16 @@ describe('ModuleManager', () => {
                             <component name="LoggerComponent">
                                 <script uri="LoggerComponent.brs" />
                                 <interface>
-                                    <function name="doSomething"/>
+                                    <function name="doSomething" />
+                                    <function name="notDefinedDoSomething" />
                                 </interface>
                             </component>
                         `,
                         'components/LoggerComponent.brs': trim`
                             sub init()
                                 doSomething()
+                                isFunction(doSomething)
+                                isFunction(notDefinedDoSomething)
                             end sub
                             sub doSomething()
                             end sub
@@ -1191,13 +1194,16 @@ describe('ModuleManager', () => {
                 <component name="logger_LoggerComponent">
                     <script uri="pkg:/components/roku_modules/logger/LoggerComponent.brs" />
                     <interface>
-                        <function name="doSomething"/>
+                        <function name="doSomething" />
+                        <function name="notDefinedDoSomething" />
                     </interface>
                 </component>
             `);
             fsEqual(`${hostDir}/components/roku_modules/logger/LoggerComponent.brs`, trim`
                 sub init()
                     doSomething()
+                    isFunction(doSomething)
+                    isFunction(notDefinedDoSomething)
                 end sub
                 sub doSomething()
                 end sub

--- a/src/prefixer/RopmModule.ts
+++ b/src/prefixer/RopmModule.ts
@@ -350,8 +350,13 @@ export class RopmModule {
 
             //prefix all identifiers that have the same name as a function
             for (const identifier of file.identifiers) {
+                const lowerName = identifier.name.toLowerCase();
+                //skip edits for special functions
+                if (nonPrefixedFunctionMap[lowerName]) {
+                    continue;
+                }
                 //if this identifier has the same name as a function, then prefix the identifier
-                if (ownFunctionMap[identifier.name.toLowerCase()]) {
+                if (ownFunctionMap[lowerName]) {
                     file.addEdit(identifier.offset, identifier.offset, prefix);
                 }
             }


### PR DESCRIPTION
Fix bug where function references do not honor prefixing whitelist.