### PR TITLE
Prefix task function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Result:
  end sub
 ```
 
+### Tasks (`m.top.functionName`)
+BrightScript Task objects have a special `m.top.functionName` property that specifies which function should be run during the task. ropm will find all instances of `m.top.functionName = "<anything>"` and add the prefix to the beginning of the string.
+
+The syntax must be exactly `m.top.functionName = ` followed by a string (i.e. `m.top.functionName = "taskCallback"`). ropm will skip the statement if anything other than a string is found to the right-hand-side of the equals sign. If you dynamically generate the value for `m.top.functionName`, or assign it in some other fashion, consider using the [ROPM_PREFIX](#ropm_prefix-source-literal) source literal instead.
 
 ### Never-prefixed functions
 Due to their special handling within the Roku architecture, the following functions  will never be prefixed:

--- a/src/TestHelpers.spec.ts
+++ b/src/TestHelpers.spec.ts
@@ -5,6 +5,9 @@ import { expect } from 'chai';
 import { RopmModule } from './prefixer/RopmModule';
 import type { RopmOptions } from './util';
 import * as rokuDeploy from 'roku-deploy';
+import { ModuleManager } from './prefixer/ModuleManager';
+import { util } from './util';
+
 export const sinon = createSandbox();
 
 export const tempDir = path.join(process.cwd(), '.tmp');
@@ -187,4 +190,52 @@ export function pick(objects: any[], ...properties: string[]) {
         results.push(result);
     }
     return results;
+}
+
+/**
+ * Streamlined way to test the ModuleManager.process functionality
+ */
+export async function testProcess(args: Record<string, [source: string, expected: string]>) {
+    const manager = new ModuleManager();
+    const hostDir = path.join(process.cwd(), '.tmp', 'hostApp');
+
+    const dependencies = [] as DepGraphNode[];
+    const expectedFileMap = new Map<string, any>();
+
+    for (const fileKey in args) {
+        const [source, expected] = args[fileKey];
+        const parts = fileKey.split(':');
+        const [dependencyName, filePath] = parts;
+
+        let dep = dependencies.find(x => x.name === dependencyName);
+        if (!dep) {
+            dep = {
+                name: dependencyName,
+                _files: {}
+            };
+            dependencies.push(dep);
+        }
+        dep._files![filePath] = source;
+        expectedFileMap.set(filePath, expected);
+    }
+
+    manager.modules = createProjects(hostDir, hostDir, {
+        name: 'host',
+        dependencies: dependencies
+    });
+
+    manager.hostDependencies = await util.getModuleDependencies(hostDir);
+    manager.noprefixNpmAliases = [];
+    await manager.process();
+
+    //copmare each output file to the expected
+    for (const dep of dependencies) {
+        for (const filePath in dep._files) {
+            const parts = filePath.split('/');
+            const baseFolder = parts.shift();
+            const remainingPath = parts.join('/');
+            const destinationPath = `${hostDir}/${baseFolder}/roku_modules/${dep.alias ?? dep.name}/${remainingPath}`;
+            fsEqual(destinationPath, expectedFileMap.get(filePath));
+        }
+    }
 }

--- a/src/prefixer/File.ts
+++ b/src/prefixer/File.ts
@@ -116,6 +116,16 @@ export class File {
     }>;
 
     /**
+     * The name of the component if this is an xml file
+     */
+    public componentName?: string;
+
+    /**
+     * The name of the parent component if this is an xml file
+     */
+    public parentComponentName?: string;
+
+    /**
      * List of functions referenced by a component's <interface> element
      */
     public componentInterfaceFunctions = [] as Array<{
@@ -378,6 +388,7 @@ export class File {
     private findComponentDefinitions() {
         const nameAttribute = this.xmlAst?.rootElement?.attributes?.find(x => x.key?.toLowerCase() === 'name');
         if (nameAttribute?.value && nameAttribute?.syntax?.value) {
+            this.componentName = nameAttribute.value.replace(/"/g, '');
             this.componentDeclarations.push({
                 name: nameAttribute.value,
                 //plus one to step past the opening "
@@ -393,6 +404,7 @@ export class File {
         //get any "extends" attribute from the xml
         const extendsAttribute = this.xmlAst?.rootElement?.attributes?.find(x => x.key?.toLowerCase() === 'extends');
         if (extendsAttribute?.value && extendsAttribute?.syntax?.value) {
+            this.parentComponentName = extendsAttribute.value.replace(/"/g, '');
             this.componentReferences.push({
                 name: extendsAttribute.value,
                 //plus one to step past the opening "

--- a/src/prefixer/File.ts
+++ b/src/prefixer/File.ts
@@ -62,11 +62,6 @@ export class File {
     }
 
     /**
-     * If this is a component, does it extend from Task (directly or indirectly)
-     */
-    public isTask = false;
-
-    /**
      * The full pkg path to the file (minus the `pkg:/` protocol since we never actually need that part)
      */
     public pkgPath: string;
@@ -128,16 +123,6 @@ export class File {
         name: string;
         offset: number;
     }>;
-
-    /**
-     * The name of the component if this is an xml file
-     */
-    public componentName?: string;
-
-    /**
-     * The name of the parent component if this is an xml file
-     */
-    public parentComponentName?: string;
 
     /**
      * List of functions referenced by a component's <interface> element
@@ -403,7 +388,6 @@ export class File {
     private findComponentDefinitions() {
         const nameAttribute = this.xmlAst?.rootElement?.attributes?.find(x => x.key?.toLowerCase() === 'name');
         if (nameAttribute?.value && nameAttribute?.syntax?.value) {
-            this.componentName = nameAttribute.value.replace(/"/g, '');
             this.componentDeclarations.push({
                 name: nameAttribute.value,
                 //plus one to step past the opening "
@@ -419,7 +403,6 @@ export class File {
         //get any "extends" attribute from the xml
         const extendsAttribute = this.xmlAst?.rootElement?.attributes?.find(x => x.key?.toLowerCase() === 'extends');
         if (extendsAttribute?.value && extendsAttribute?.syntax?.value) {
-            this.parentComponentName = extendsAttribute.value.replace(/"/g, '');
             this.componentReferences.push({
                 name: extendsAttribute.value,
                 //plus one to step past the opening "
@@ -587,8 +570,6 @@ export class File {
 
     /**
      * Look for every statement that looks exactly like the default task functionName assignment.
-     * These are not necessarily all used...as the RopmModule class will determie if ours should be used based on
-     * whether this script is included in a Task or not
      */
     private findTaskFunctionNameAssignments() {
         //look for any string containing `m.top.functionName = "<anything>"`

--- a/src/prefixer/ModuleManager.spec.ts
+++ b/src/prefixer/ModuleManager.spec.ts
@@ -1315,7 +1315,7 @@ describe('ModuleManager', () => {
             });
         });
 
-        it('prefixes task functionName', async () => {
+        it('does not prefix m.top.functionName for files NOT imported by a Task', async () => {
             await testProcess({
                 'logger:source/lib.brs': [
                     trim`
@@ -1331,7 +1331,7 @@ describe('ModuleManager', () => {
             });
         });
 
-        it.only('prefixes direct task reference from component in same module', async () => {
+        it('prefixes direct task reference from component in same module', async () => {
             await testProcess({
                 'logger:components/SimpleTask.brs': [
                     trim`
@@ -1356,7 +1356,7 @@ describe('ModuleManager', () => {
             });
         });
 
-        it.only('prefixes indirect task reference from component in same module', async () => {
+        it('prefixes indirect task reference from component in same module', async () => {
             await testProcess({
                 'logger:components/HardTask.brs': [
                     trim`
@@ -1386,7 +1386,8 @@ describe('ModuleManager', () => {
             });
         });
 
-        it.only('prefixes indirect task reference from component in different module', async () => {
+        //TODO should we even support this?
+        it.skip('prefixes indirect task reference from component in different module', async () => {
             await testProcess({
                 'logger:components/HardTask.brs': [
                     trim`

--- a/src/prefixer/ModuleManager.spec.ts
+++ b/src/prefixer/ModuleManager.spec.ts
@@ -1315,7 +1315,7 @@ describe('ModuleManager', () => {
             });
         });
 
-        it('does not prefix m.top.functionName for files NOT imported by a Task', async () => {
+        it('prefixes m.top.functionName for files NOT imported by a Task', async () => {
             await testProcess({
                 'logger:source/lib.brs': [
                     trim`
@@ -1325,7 +1325,7 @@ describe('ModuleManager', () => {
                     `,
                     trim`
                         sub logger_a()
-                            m.top.functionName = "doSomething"
+                            m.top.functionName = "logger_doSomething"
                         end sub
                     `]
             });
@@ -1386,8 +1386,7 @@ describe('ModuleManager', () => {
             });
         });
 
-        //TODO should we even support this?
-        it.skip('prefixes indirect task reference from component in different module', async () => {
+        it('prefixes indirect task reference from component in different module', async () => {
             await testProcess({
                 'logger:components/HardTask.brs': [
                     trim`

--- a/src/prefixer/RopmModule.ts
+++ b/src/prefixer/RopmModule.ts
@@ -5,8 +5,8 @@ import * as path from 'path';
 import * as packlist from 'npm-packlist';
 import * as rokuDeploy from 'roku-deploy';
 import type { Dependency } from './ModuleManager';
-import type { Program } from 'brighterscript';
-import { ProgramBuilder } from 'brighterscript';
+import type { Program, XmlFile } from 'brighterscript';
+import { ProgramBuilder, standardizePath as s } from 'brighterscript';
 import { LogLevel } from 'brighterscript/dist/Logger';
 
 export class RopmModule {
@@ -50,6 +50,8 @@ export class RopmModule {
         //package authors should exclude `roku_modules` during publishing, but things might slip through the cracks, so exclude those during ropm install
         '!**/roku_modules/**/*'
     ];
+
+    public files = [] as File[];
 
     /**
      * The name of this module. Users can rename modules on install-time, so this is the folder we must use
@@ -101,9 +103,15 @@ export class RopmModule {
     public dominantVersion!: string;
 
     /**
-     * A map of every compoent by component name
+     * A map of every compoent by component name.
+     * The key is all lower case component name
      */
     public componentMap = new Map<string, File>();
+
+    /**
+     * An array of every script referenced by a Task
+     */
+    public taskScripts!: Map<string, string>;
 
     public isValid = true;
 
@@ -237,12 +245,18 @@ export class RopmModule {
 
         //let all files discover all functions/components
         for (const file of this.files) {
+            file.discover(this.program);
+
             //add xml file to the component map
             if (file.isXmlFile) {
-                this.componentMap.set(file.componentName!, file);
+                this.componentMap.set(file.componentName!.toLowerCase(), file);
             }
-            file.discover(this.program);
         }
+
+        //discover every task component
+        this.discoverTaskComponents();
+
+        this.discoverTaskScripts();
 
         //create the edits for every file
         this.createEdits(noprefixRopmAliases);
@@ -326,6 +340,13 @@ export class RopmModule {
         for (const file of this.files) {
             //only apply prefixes if configured to do so
             if (applyOwnPrefix) {
+
+                // if this file is a script referenced by a task, prefix `m.top.functionName` assignments
+                if (this.taskScripts.has(s`${file.pkgPath.toLowerCase()}`)) {
+                    for (const ref of file.taskFunctionNameAssignments) {
+                        file.addEdit(ref.offset, ref.offset, prefix);
+                    }
+                }
 
                 //create an edit for each this-module-owned function
                 for (const func of file.functionDefinitions) {
@@ -551,6 +572,48 @@ export class RopmModule {
         return Object.keys(result);
     }
 
+    /**
+     * Mark every file that is a component and extends a Task (directly or indirectly)
+     */
+    private discoverTaskComponents() {
+        for (const file of this.files) {
+            if (file.isXmlFile && file.parentComponentName) {
 
-    public files = [] as File[];
+                let parent: File | undefined = file;
+
+                //walk ancestors until we can't find one. (loop to 50 just to guard against infinite loops)
+                while (parent) {
+                    //if there is no parent, then this file is not a task
+                    if (!parent) {
+                        break;
+                    }
+                    if (parent.parentComponentName?.toLowerCase() === 'task') {
+                        file.isTask = true;
+                        break;
+                    }
+                    parent = this.componentMap.get(file.parentComponentName.toLowerCase());
+                }
+            }
+        }
+    }
+
+    /**
+     * Build the list of every script that is referenced by at least one task
+     */
+    private discoverTaskScripts() {
+        this.taskScripts = new Map<string, string>();
+        for (const file of this.componentMap.values()) {
+            //only capture scripts from Tasks
+            if (file.isTask) {
+                //get this file from the program
+                const bscFile = this.program.getFileByPathAbsolute<XmlFile>(file.srcPath);
+                for (const importPath of bscFile.getAvailableScriptImports()) {
+                    const lowerImport = s`${importPath.toLowerCase()}`;
+                    if (!this.taskScripts.has(lowerImport)) {
+                        this.taskScripts.set(lowerImport, importPath);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/prefixer/RopmModule.ts
+++ b/src/prefixer/RopmModule.ts
@@ -100,6 +100,11 @@ export class RopmModule {
      */
     public dominantVersion!: string;
 
+    /**
+     * A map of every compoent by component name
+     */
+    public componentMap = new Map<string, File>();
+
     public isValid = true;
 
     public async init() {
@@ -232,6 +237,10 @@ export class RopmModule {
 
         //let all files discover all functions/components
         for (const file of this.files) {
+            //add xml file to the component map
+            if (file.isXmlFile) {
+                this.componentMap.set(file.componentName!, file);
+            }
             file.discover(this.program);
         }
 


### PR DESCRIPTION
to define the function to run in a Task, you execute `m.top.functionName` from a script referenced by the task. ropm wasn't properly prefixing those, so this PR will handle that situation. 

This does mean that no ropm packages may use `functionName` as an xml filed anymore, unless they are willing to change the value without using the `m.top.functionName` syntax. But that is a fair tradeoff, in my opinion.