### PR TITLE
Possibility to pass rootDir as Copy- and InstallCommand arg

### DIFF
--- a/src/commands/CopyCommand.ts
+++ b/src/commands/CopyCommand.ts
@@ -18,4 +18,8 @@ export interface CopyCommandArgs {
      * The current working directory for the command.
      */
     cwd?: string;
+    /**
+     * Dependencies installation location
+     */
+    rootDir?: string;
 }

--- a/src/commands/InstallCommand.spec.ts
+++ b/src/commands/InstallCommand.spec.ts
@@ -59,7 +59,7 @@ describe('InstallCommand', () => {
             )).to.be.true;
         });
 
-        it('uses dependency package.json ropm.rootDir when specified', async () => {
+        it('uses dependency package.json ropm.packageRootDir when specified', async () => {
 
             writeProject('logger', {
                 'src/source/logger.brs': ''
@@ -139,6 +139,35 @@ describe('InstallCommand', () => {
             )).to.be.true;
             expect(fsExtra.pathExistsSync(
                 path.join(projectDir, 'src', 'source', 'roku_modules', 'logger', 'temp.brs')
+            )).to.be.true;
+        });
+
+        it('honors rootDir arg over package.json `ropm.rootDir` property', async () => {
+            args.rootDir = 'anotherSrc';
+
+            writeProject('logger', {
+                'source/logger.brs': '',
+                'source/temp.brs': ''
+            });
+
+            writeProject(projectName, {
+                'anotherSrc/source/main.brs': ''
+            }, {
+                dependencies: {
+                    'logger': `file:../logger`
+                },
+                ropm: {
+                    rootDir: 'src'
+                }
+            });
+
+            await command.run();
+
+            expect(fsExtra.pathExistsSync(
+                path.join(projectDir, 'anotherSrc', 'source', 'roku_modules', 'logger', 'logger.brs')
+            )).to.be.true;
+            expect(fsExtra.pathExistsSync(
+                path.join(projectDir, 'anotherSrc', 'source', 'roku_modules', 'logger', 'temp.brs')
             )).to.be.true;
         });
 

--- a/src/commands/InstallCommand.ts
+++ b/src/commands/InstallCommand.ts
@@ -140,7 +140,9 @@ export interface InstallCommandArgs {
      */
     packages?: string[];
     /**
-     * Dependencies installation location
+     * Dependencies installation location.
+     * By default the setting from package.json is imported out-of-the-box, but if rootDir is passed here,
+     * it will override the value from package.json.
      */
     rootDir?: string;
 }

--- a/src/commands/InstallCommand.ts
+++ b/src/commands/InstallCommand.ts
@@ -19,7 +19,7 @@ export class InstallCommand {
     private moduleManager = new ModuleManager();
 
     private get hostRootDir() {
-        const packageJsonRootDir = this.hostPackageJson?.ropm?.rootDir;
+        const packageJsonRootDir = this.args.rootDir ?? this.hostPackageJson?.ropm?.rootDir;
         if (packageJsonRootDir) {
             return path.resolve(this.cwd, packageJsonRootDir);
         } else {
@@ -139,4 +139,8 @@ export interface InstallCommandArgs {
      * The list of packages that should be installed
      */
     packages?: string[];
+    /**
+     * Dependencies installation location
+     */
+    rootDir?: string;
 }


### PR DESCRIPTION
Hey, I'm working on a custom dependencies importer, and for files copying and prefixing I used this cool library. I don't use CLI but directly use CopyComand and found it unnecessarily limiting to have package.json as the only config possibility.
IMO, ideally, these commands shouldn't be responsible for fetching config and aware of config placement - config should be passed as constructor argument or imported from a different entity. Anyway, I didn't want to rearrange your code so I decided to suggest the simplest, full-config-passing-ready solution