### PR TITLE
fix: Ignoring prod subdependencies without ropm keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules*
 dist
+.idea
 .tmp
 dist
 .nyc_output

--- a/src/commands/InstallCommand.spec.ts
+++ b/src/commands/InstallCommand.spec.ts
@@ -301,8 +301,8 @@ describe('InstallCommand', () => {
 
             await command.run();
             expect(fsExtra.pathExistsSync(
-                path.join(projectDir, 'source', 'roku_modules', 'maestro')
-            )).to.be.false;
+                path.join(projectDir, 'source', 'roku_modules', 'maestro_v1')
+            )).to.be.true;
         });
 
         it('ignores prod dependencies of prod dependencies that are missing the "ropm" keyword', async () => {
@@ -330,7 +330,7 @@ describe('InstallCommand', () => {
 
             await command.run();
             expect(fsExtra.pathExistsSync(
-                path.join(projectDir, 'source', 'roku_modules', 'maestro')
+                path.join(projectDir, 'source', 'roku_modules', 'maestro_v1')
             )).to.be.false;
         });
 

--- a/src/commands/InstallCommand.ts
+++ b/src/commands/InstallCommand.ts
@@ -112,7 +112,7 @@ export class InstallCommand {
         }
         let stdout: string;
         try {
-            stdout = childProcess.execSync('npm ls --parseable --prod', {
+            stdout = childProcess.execSync('npm ls --parseable --prod --depth=99', {
                 cwd: this.cwd
             }).toString();
         } catch (e) {

--- a/src/commands/InstallCommand.ts
+++ b/src/commands/InstallCommand.ts
@@ -112,7 +112,7 @@ export class InstallCommand {
         }
         let stdout: string;
         try {
-            stdout = childProcess.execSync('npm ls --parseable --prod --depth=99', {
+            stdout = childProcess.execSync('npm ls --parseable --prod --depth=Infinity', {
                 cwd: this.cwd
             }).toString();
         } catch (e) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -182,12 +182,14 @@ export class Util {
                     throw new Error(`Could not resolve dependency "${npmAlias}" for "${moduleDir}"`);
                 }
                 const packageJson = await util.getPackageJson(dependencyDir);
-                result.push({
-                    npmAlias: npmAlias,
-                    ropmModuleName: util.getRopmNameFromModuleName(npmAlias),
-                    npmModuleName: packageJson.name,
-                    version: packageJson.version
-                });
+                if ((packageJson.keywords ?? []).includes('ropm')) {
+                    result.push({
+                        npmAlias: npmAlias,
+                        ropmModuleName: util.getRopmNameFromModuleName(npmAlias),
+                        npmModuleName: packageJson.name,
+                        version: packageJson.version
+                    });
+                }
             })
         );
 


### PR DESCRIPTION
Currently, if a prod dependency has another prod dependency that has no "ropm" keyword, ROPM is crashing.
Since NPM v7, the default depth is 1. This change doesn't break on NPM v6 (which has infinity depth by default)