### PR TITLE
feat!: Installing direct dev dependencies

### DIFF
--- a/src/commands/InstallCommand.ts
+++ b/src/commands/InstallCommand.ts
@@ -112,7 +112,7 @@ export class InstallCommand {
         }
         let stdout: string;
         try {
-            stdout = childProcess.execSync('npm ls --parseable --prod', {
+            stdout = childProcess.execSync('npm ls --parseable', {
                 cwd: this.cwd
             }).toString();
         } catch (e) {


### PR DESCRIPTION
This PR makes ROPM logic the same as NPM which installs in the main node_modules directory:
- all prod dependencies and their prod dependencies recursively
- all direct dev dependencies and their prod dependencies recursively

Until now all dev dependencies weren't copied because of using the `--prod` flag. Both NPM v6 and v7 do return dependencies listed above by default (the only difference is that since v7 depth is set to 1 by default, but I'm fixing it in another PR).

Why **direct** dev dependencies should be copied by ROPM too? For example to be able to set up a unit testing framework as a dev dependency. Because of Roku's technical limitations, the majority of unit testing frameworks add some files into a package to run tests. Without this change the unit testing framework has to be set as a production dependency therefore if used in a library module we use in our frontend app, it would be automatically copied into the production app code because it would be a prod dependency of direct app's prod dependency.

PS This is the last PR of the series of changes I was working on.