### PR TITLE
fix!: Avoiding version postfix if there is only one version of module installed

### DIFF
--- a/src/prefixer/ModuleManager.spec.ts
+++ b/src/prefixer/ModuleManager.spec.ts
@@ -67,7 +67,7 @@ describe('ModuleManager', () => {
                 npmModuleName: 'promise',
                 dominantVersion: '1',
                 version: '1.0.0',
-                ropmModuleName: 'promise_v1'
+                ropmModuleName: 'promise'
             }]);
         });
 
@@ -129,7 +129,7 @@ describe('ModuleManager', () => {
                 npmModuleName: 'cool-package',
                 dominantVersion: '4.0.0-b4',
                 version: '4.0.0-b4',
-                ropmModuleName: 'coolpackage_v4_0_0_b4'
+                ropmModuleName: 'coolpackage'
             }]);
         });
 
@@ -251,7 +251,7 @@ describe('ModuleManager', () => {
 
             fsEqual(`${hostDir}/source/roku_modules/logger/main.brs`, `
                 sub logger_WriteToLog(message)
-                    return complexlogger_v1_writeToLog(message)
+                    return complexlogger_writeToLog(message)
                 end sub
             `);
         });
@@ -440,7 +440,7 @@ describe('ModuleManager', () => {
 
             fsEqual(`${hostDir}/source/roku_modules/logger/main.brs`, `
                 sub logger_PrintValue(value)
-                    print bravo_printer_v1_writeLine(value)
+                    print bravo_printer_writeLine(value)
                 end sub
             `);
         });
@@ -736,8 +736,8 @@ describe('ModuleManager', () => {
             fsEqual(`${hostDir}/components/roku_modules/logger/Component1.xml`, `
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="logger_Component1">
-                    <script uri="pkg:/source/roku_modules/promise_v1/promise.brs" />
-                    <script uri="pkg:/source/roku_modules/promise_v1/promise.brs" />
+                    <script uri="pkg:/source/roku_modules/promise/promise.brs" />
+                    <script uri="pkg:/source/roku_modules/promise/promise.brs" />
                 </component>
             `);
         });
@@ -771,7 +771,7 @@ describe('ModuleManager', () => {
                     <children>
                         <Poster uri="pkg:/images/roku_modules/logger/photo.jpg" />
                         <!--dependency paths-->
-                        <Poster uri="pkg:/images/roku_modules/photolib_v1/photo.jpg" />
+                        <Poster uri="pkg:/images/roku_modules/photolib/photo.jpg" />
                     </children>
                 </component>
             `);
@@ -1119,7 +1119,7 @@ describe('ModuleManager', () => {
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="logger_loggercomp">
                     <children>
-                        <smartlist_v1_SimpleList></smartlist_v1_SimpleList>
+                        <smartlist_SimpleList></smartlist_SimpleList>
                     </children>
                 </component>
             `);
@@ -1422,9 +1422,9 @@ describe('ModuleManager', () => {
             fsEqual(`${hostDir}/source/roku_modules/logger/lib.d.bs`, `
                 namespace logger
                 class Person
-                    sub new(pet as animals_v1.Duck)
+                    sub new(pet as animals.Duck)
                     end sub
-                    sub watchPetForFriend(friendPet as dogs_v1.Poodle)
+                    sub watchPetForFriend(friendPet as dogs.Poodle)
                     end sub
                 end class
                 end namespace

--- a/src/prefixer/ModuleManager.ts
+++ b/src/prefixer/ModuleManager.ts
@@ -161,13 +161,20 @@ export class ModuleManager {
                     version = semver.maxSatisfying([obj.highestVersion, hostDependency?.version ?? '0.0.0'], '*') as string;
                 }
 
+                let ropmModuleName: string;
+                if (hostDependency?.npmAlias) {
+                    ropmModuleName = util.getRopmNameFromModuleName(hostDependency.npmAlias);
+                } else if (dominantVersions.length === 1) {
+                    ropmModuleName = util.getRopmNameFromModuleName(moduleName);
+                } else {
+                    ropmModuleName = `${util.getRopmNameFromModuleName(moduleName)}_v${dominantVersionIdentifier}`;
+                }
+
                 result.push({
                     dominantVersion: dominantVersion.toString(),
                     npmModuleName: moduleName,
                     //use the hosts's alias, or default to the module name
-                    ropmModuleName: hostDependency?.npmAlias
-                        ? util.getRopmNameFromModuleName(hostDependency.npmAlias)
-                        : `${util.getRopmNameFromModuleName(moduleName)}_v${dominantVersionIdentifier}`,
+                    ropmModuleName: ropmModuleName,
                     version: version
                 });
             }

--- a/src/prefixer/RopmModule.ts
+++ b/src/prefixer/RopmModule.ts
@@ -316,16 +316,14 @@ export class RopmModule {
         const prefixMapKeysLower = prefixMapKeys.map(x => x.toLowerCase());
 
         /**
-         * Get the alias for a namespace. Only returns if it exists and is different than what is given.
+         * Get the alias for a namespace.
          */
         const getAlias = (namespace?: string) => {
             if (namespace) {
                 const lowerNamespaceName = namespace.toLowerCase();
                 const idx = prefixMapKeysLower.indexOf(lowerNamespaceName);
-                const prefix = this.prefixMap[prefixMapKeys[idx]];
-                if (prefix && prefix.toLowerCase() !== lowerNamespaceName) {
-                    return prefix;
-                }
+
+                return this.prefixMap[prefixMapKeys[idx]];
             }
         };
 


### PR DESCRIPTION
Without this change even if there is just one major version of a module in the dependency list, it will be locally (ROPM module name) postfixed (like `_v1`). However the list set as ModuleManager.noprefixRopmAliases doesn't contain such postfixes therefore the "noprefix" option works only for modules that were aliased (because they can be matched in RopmModule.createEdits due to no version postfix).

The question is what should be the behaviour when an NPM module is set as "noprefix" but there are its two major versions in use. I would say an error should be thrown. Anyway, it wasn't handled so far so I ignored it.