### PR TITLE
Process nonstandard dirs that contain brs/xml files

### DIFF
--- a/src/commands/InstallCommand.spec.ts
+++ b/src/commands/InstallCommand.spec.ts
@@ -62,6 +62,30 @@ describe('InstallCommand', () => {
             )).to.be.true;
         });
 
+        it('processes non-default folder paths', async () => {
+            //main project
+            writeProject(projectName, {
+                'source/main.brs': ''
+            }, {
+                dependencies: {
+                    'logger': `file:../logger`
+                }
+            });
+
+            //lib
+            writeProject('logger', {
+                'nonStandardFolder/logger.brs': 'sub log()\nend sub'
+            });
+
+            await command.run();
+
+            expect(
+                fsExtra.readFileSync(s`${projectDir}/nonStandardFolder/roku_modules/logger/logger.brs`).toString()
+            ).to.eql(
+                'sub logger_log()\nend sub'
+            );
+        });
+
         it('uses dependency package.json ropm.packageRootDir when specified', async () => {
 
             writeProject('logger', {

--- a/src/prefixer/RopmModule.ts
+++ b/src/prefixer/RopmModule.ts
@@ -210,7 +210,6 @@ export class RopmModule {
 
         //disable the Program.validate function to improve performance (we don't care about the validity of the code...that should be handled by the package publisher)
         util.mockProgramValidate();
-
         await builder.run({
             //specify an optional bogus bsconfig which prevents loading any bsconfig found in cwd
             project: '?___not-real-bsconfig.json",',
@@ -221,7 +220,13 @@ export class RopmModule {
             //hide all diagnostics, the package author should be responsible for ensuring their package is valid
             diagnosticFilters: ['**/*'],
             //hide log statements
-            logLevel: LogLevel.error
+            logLevel: LogLevel.error,
+            //include all files except node_modules and roku_modules (publishers SHOULD be excluding those, but might not)
+            files: [
+                '**/*',
+                '!**/roku_modules/**/*',
+                '!**/node_modules/**/*'
+            ]
         });
         this.program = builder.program;
 


### PR DESCRIPTION
Fixes an issue where ropm was not properly processing brs/xml files found in nonstandard folders (i.e. not `/source` or `/components`). 