### PR TITLE
Fixes missing prefixes in .bs and d.bs files for interfaces, enums, and constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "1.0.10",
-        "brighterscript": "^0.67.8",
+        "brighterscript": "^0.68.0",
         "del": "6.0.0",
         "fs-extra": "9.1.0",
         "glob-all": "3.2.1",
@@ -1727,9 +1727,9 @@
       }
     },
     "node_modules/brighterscript": {
-      "version": "0.67.8",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.67.8.tgz",
-      "integrity": "sha512-2pQcPzW/NCEEofojLuHRDcLuQTmHssNpj1xW2oRiSFMo0YHR5cBIHrG/I71lpJwpyw/HzzK0vcEbthlOW4QVuw==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.68.0.tgz",
+      "integrity": "sha512-UKxzMHJo9QhOmcIrfjB0ICjWoK3b6PGJ4AnKPCg8GYF1FR6IW+03Q8MinTR0iTjlC0DbiXTvc9GS+1tUTAOi4Q==",
       "dependencies": {
         "@rokucommunity/bslib": "^0.1.1",
         "@rokucommunity/logger": "^0.3.9",
@@ -9409,9 +9409,9 @@
       }
     },
     "brighterscript": {
-      "version": "0.67.8",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.67.8.tgz",
-      "integrity": "sha512-2pQcPzW/NCEEofojLuHRDcLuQTmHssNpj1xW2oRiSFMo0YHR5cBIHrG/I71lpJwpyw/HzzK0vcEbthlOW4QVuw==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.68.0.tgz",
+      "integrity": "sha512-UKxzMHJo9QhOmcIrfjB0ICjWoK3b6PGJ4AnKPCg8GYF1FR6IW+03Q8MinTR0iTjlC0DbiXTvc9GS+1tUTAOi4Q==",
       "requires": {
         "@rokucommunity/bslib": "^0.1.1",
         "@rokucommunity/logger": "^0.3.9",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "1.0.10",
-    "brighterscript": "^0.67.8",
+    "brighterscript": "^0.68.0",
     "del": "6.0.0",
     "fs-extra": "9.1.0",
     "glob-all": "3.2.1",

--- a/src/prefixer/File.ts
+++ b/src/prefixer/File.ts
@@ -86,7 +86,7 @@ export class File {
         endOffset: number;
     }>;
 
-    public classDeclarations = [] as Array<{
+    public prefixableDeclarations = [] as Array<{
         name: string;
         nameOffset: number;
         hasNamespace: boolean;
@@ -170,48 +170,6 @@ export class File {
     public namespaces = [] as Array<{
         name: string;
         offset: number;
-    }>;
-
-    public enumDeclarations = [] as Array<{
-        name: string;
-        nameOffset: number;
-        hasNamespace: boolean;
-        /**
-         * The starting offset of `enum`
-         */
-        startOffset: number;
-        /**
-         * The end offset of `end enum`
-         */
-        endOffset: number;
-    }>;
-
-    public constDeclarations = [] as Array<{
-        name: string;
-        nameOffset: number;
-        hasNamespace: boolean;
-        /**
-         * The starting offset of `const`
-         */
-        startOffset: number;
-        /**
-         * The end offset of `end const`
-         */
-        endOffset: number;
-    }>;
-
-    public interfaceDeclarations = [] as Array<{
-        name: string;
-        nameOffset: number;
-        hasNamespace: boolean;
-        /**
-         * The starting offset of `interface`
-         */
-        startOffset: number;
-        /**
-         * The end offset of `end interface`
-         */
-        endOffset: number;
     }>;
 
     private edits = [] as Edit[];
@@ -385,7 +343,7 @@ export class File {
             //track class declarations (.bs and .d.bs only)
             ClassStatement: (cls) => {
                 const annotations = cls.annotations ?? [];
-                this.classDeclarations.push({
+                this.prefixableDeclarations.push({
                     name: cls.name.text,
                     nameOffset: this.positionToOffset(cls.name.range.start),
                     hasNamespace: !!cls.namespaceName,
@@ -419,7 +377,7 @@ export class File {
             //track enum declarations (.bs and .d.bs only)
             EnumStatement: (node) => {
                 const annotations = node.annotations ?? [];
-                this.enumDeclarations.push({
+                this.prefixableDeclarations.push({
                     name: node.tokens.name.text,
                     nameOffset: this.positionToOffset(node.tokens.name.range.start),
                     hasNamespace: !!node.namespaceName,
@@ -433,7 +391,7 @@ export class File {
             //track enum declarations (.bs and .d.bs only)
             ConstStatement: (node) => {
                 const annotations = node.annotations ?? [];
-                this.constDeclarations.push({
+                this.prefixableDeclarations.push({
                     name: node.tokens.name.text,
                     nameOffset: this.positionToOffset(node.tokens.name.range.start),
                     hasNamespace: !!node.findAncestor(isNamespaceStatement),
@@ -447,7 +405,7 @@ export class File {
             //track enum declarations (.bs and .d.bs only)
             InterfaceStatement: (node) => {
                 const annotations = node.annotations ?? [];
-                this.interfaceDeclarations.push({
+                this.prefixableDeclarations.push({
                     name: node.tokens.name.text,
                     nameOffset: this.positionToOffset(node.tokens.name.range.start),
                     hasNamespace: !!node.findAncestor(isNamespaceStatement),

--- a/src/prefixer/File.ts
+++ b/src/prefixer/File.ts
@@ -5,8 +5,15 @@ import { buildAst } from '@xml-tools/ast';
 import type { RopmOptions } from '../util';
 import { util } from '../util';
 import * as path from 'path';
-import type { BrsFile, Position, Program, Range, XmlFile } from 'brighterscript';
-import { ParseMode, createVisitor, isCallExpression, isCustomType, isDottedGetExpression, isDottedSetStatement, isIndexedGetExpression, isIndexedSetStatement, WalkMode, util as bsUtil, isNamespaceStatement } from 'brighterscript';
+import type { BrsFile, Position, Program, Range, XmlFile, NamespaceStatement } from 'brighterscript';
+import { ParseMode, createVisitor, isCallExpression, isCustomType, isDottedGetExpression, isDottedSetStatement, isIndexedGetExpression, isIndexedSetStatement, WalkMode, util as bsUtil, isNamespaceStatement, DeclarableTypes } from 'brighterscript';
+
+/**
+ * List of all declaralbe types in BrighterScript (i.e. the native types), stored in lower case for reference
+ */
+const nativeTypes = new Set(
+    DeclarableTypes.map(x => x.toLowerCase())
+);
 
 export class File {
     constructor(
@@ -285,10 +292,23 @@ export class File {
         }
     }
 
-    private addPrefixableRef(name: string, containingNamespace: string | undefined, range: Range) {
+    private tryAddPrefixableRef(options: {
+        name: string | undefined;
+        containingNamespace: string | undefined;
+        range: Range | undefined;
+    }) {
+        //skip if we don't have a name or a range
+        if (!options.name || !options.range) {
+            return;
+        }
 
-        const lowerName = name.toLowerCase();
-        const lowerContainingNamespace = containingNamespace?.toLowerCase();
+        //skip if this is a native type, don't prefix it
+        if (options.name.trim().length > 0 && nativeTypes.has(options.name.toLowerCase())) {
+            return;
+        }
+
+        const lowerName = options.name.toLowerCase();
+        const lowerContainingNamespace = options.containingNamespace?.toLowerCase();
 
         const scopes = this.bscFile.program.getScopesForFile(this.bscFile);
         let fullyQualifiedName: string | undefined;
@@ -315,9 +335,9 @@ export class File {
         }
 
         this.prefixableReferences.push({
-            fullyQualifiedName: fullyQualifiedName ?? bsUtil.getFullyQualifiedClassName(name, containingNamespace),
-            offsetBegin: this.positionToOffset(range.start),
-            offsetEnd: this.positionToOffset(range.end)
+            fullyQualifiedName: fullyQualifiedName ?? bsUtil.getFullyQualifiedClassName(options.name, options.containingNamespace),
+            offsetBegin: this.positionToOffset(options.range.start),
+            offsetEnd: this.positionToOffset(options.range.end)
         });
     }
 
@@ -376,13 +396,25 @@ export class File {
                     endOffset: this.positionToOffset(cls.end.range.end)
                 });
 
-                if (cls.parentClassName) {
-                    this.addPrefixableRef(
-                        cls.parentClassName.getName(ParseMode.BrighterScript),
-                        cls.namespaceName?.getName(ParseMode.BrighterScript),
-                        cls.parentClassName.range!
-                    );
-                }
+                this.tryAddPrefixableRef({
+                    name: cls.parentClassName?.getName(ParseMode.BrighterScript),
+                    containingNamespace: cls.namespaceName?.getName(ParseMode.BrighterScript),
+                    range: cls.parentClassName?.range
+                });
+            },
+            FieldStatement: (node) => {
+                this.tryAddPrefixableRef({
+                    name: node.type?.text,
+                    containingNamespace: node.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript),
+                    range: node.type?.range
+                });
+            },
+            InterfaceFieldStatement: (node) => {
+                this.tryAddPrefixableRef({
+                    name: node.tokens.type?.text,
+                    containingNamespace: node.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript),
+                    range: node.tokens.type?.range
+                });
             },
             //track enum declarations (.bs and .d.bs only)
             EnumStatement: (node) => {
@@ -430,20 +462,18 @@ export class File {
                 const namespaceName = func.namespaceName?.getName(ParseMode.BrighterScript);
                 //any parameters containing custom types
                 for (const param of func.parameters) {
-                    if (isCustomType(param.type)) {
-                        this.addPrefixableRef(
-                            param.type.name,
-                            namespaceName,
-                            param.typeToken!.range
-                        );
-                    }
+                    this.tryAddPrefixableRef({
+                        name: param.typeToken?.text,
+                        containingNamespace: namespaceName,
+                        range: param.typeToken?.range
+                    });
                 }
                 if (isCustomType(func.returnType)) {
-                    this.addPrefixableRef(
-                        func.returnType.name,
-                        namespaceName,
-                        func.returnTypeToken!.range
-                    );
+                    this.tryAddPrefixableRef({
+                        name: func.returnTypeToken?.text,
+                        containingNamespace: namespaceName,
+                        range: func.returnTypeToken?.range
+                    });
                 }
             },
             FunctionStatement: (func) => {
@@ -454,7 +484,7 @@ export class File {
                     hasNamespace: !!func.namespaceName,
                     //Use annotation start position if available, otherwise use keyword
                     startOffset: this.positionToOffset(
-                        (annotations?.length > 0 ? annotations[0] : func.func.functionType)!.range.start
+                        (annotations?.length > 0 ? annotations[0] : func.func.functionType)!.range.start as Position
                     ),
                     endOffset: this.positionToOffset(func.func.end.range.end)
                 });

--- a/src/prefixer/ModuleManager.spec.ts
+++ b/src/prefixer/ModuleManager.spec.ts
@@ -1733,12 +1733,95 @@ describe('ModuleManager', () => {
             });
         });
 
-        it('prefixes enums and interfaces in function param types', async () => {
+        it('prefixes enums, classes, and interfaces in function param types', async () => {
             await testProcess({
                 'logger:source/lib.d.bs': [
                     trim`
-                        function move(direction as Direction, vid as Video)
+                        function move(direction as Direction, vid as Video, mov as Movie)
                         end function
+                        enum Direction
+                            up
+                        end enum
+                        interface Video
+                            uri as string
+                        end interface
+                        class Movie
+                            uri as string
+                        end class
+                    `,
+                    trim`
+                        namespace logger
+                        function move(direction as logger.Direction, vid as logger.Video, mov as logger.Movie)
+                        end function
+                        end namespace
+                        namespace logger
+                        enum Direction
+                            up
+                        end enum
+                        end namespace
+                        namespace logger
+                        interface Video
+                            uri as string
+                        end interface
+                        end namespace
+                        namespace logger
+                        class Movie
+                            uri as string
+                        end class
+                        end namespace
+                    `
+                ]
+            });
+        });
+
+        it('prefixes enums, classes, and interfaces in interface members', async () => {
+            await testProcess({
+                'logger:source/lib.d.bs': [
+                    trim`
+                        interface Video
+                            whichWay as Direction
+                            thingToPlay as Video
+                            parent as Movie
+                        end interface
+                        enum Direction
+                            up
+                        end enum
+                        class Movie
+                            uri as string
+                        end class
+                    `,
+                    trim`
+                        namespace logger
+                        interface Video
+                            whichWay as logger.Direction
+                            thingToPlay as logger.Video
+                            parent as logger.Movie
+                        end interface
+                        end namespace
+                        namespace logger
+                        enum Direction
+                            up
+                        end enum
+                        end namespace
+                        namespace logger
+                        class Movie
+                            uri as string
+                        end class
+                        end namespace
+                    `
+                ]
+            });
+        });
+
+        it('prefixes enums, classes, and interfaces in class members', async () => {
+            await testProcess({
+                'logger:source/lib.d.bs': [
+                    trim`
+                        class Movie
+                            whichWay as Direction
+                            thingToPlay as Video
+                            parent as Movie
+                        end class
                         enum Direction
                             up
                         end enum
@@ -1748,8 +1831,11 @@ describe('ModuleManager', () => {
                     `,
                     trim`
                         namespace logger
-                        function move(direction as logger.Direction, vid as logger.Video)
-                        end function
+                        class Movie
+                            whichWay as logger.Direction
+                            thingToPlay as logger.Video
+                            parent as logger.Movie
+                        end class
                         end namespace
                         namespace logger
                         enum Direction

--- a/src/prefixer/ModuleManager.spec.ts
+++ b/src/prefixer/ModuleManager.spec.ts
@@ -1690,7 +1690,7 @@ describe('ModuleManager', () => {
             });
         });
 
-        it('wraps top-level functions and classes with a namespace', async () => {
+        it('wraps top-level declarations with a namespace', async () => {
             await testProcess({
                 'logger:source/lib.d.bs': [
                     trim`
@@ -1698,6 +1698,13 @@ describe('ModuleManager', () => {
                         end function
                         class Person
                         end class
+                        enum Direction
+                            up = "up"
+                        end enum
+                        const PI = 3.14
+                        interface Movie
+                            uri as string
+                        end interface
                     `,
                     trim`
                         namespace logger
@@ -1707,6 +1714,52 @@ describe('ModuleManager', () => {
                         namespace logger
                         class Person
                         end class
+                        end namespace
+                        namespace logger
+                        enum Direction
+                            up = "up"
+                        end enum
+                        end namespace
+                        namespace logger
+                        const PI = 3.14
+                        end namespace
+                        namespace logger
+                        interface Movie
+                            uri as string
+                        end interface
+                        end namespace
+                    `
+                ]
+            });
+        });
+
+        it('prefixes enums and interfaces in function param types', async () => {
+            await testProcess({
+                'logger:source/lib.d.bs': [
+                    trim`
+                        function move(direction as Direction, vid as Video)
+                        end function
+                        enum Direction
+                            up
+                        end enum
+                        interface Video
+                            uri as string
+                        end interface
+                    `,
+                    trim`
+                        namespace logger
+                        function move(direction as logger.Direction, vid as logger.Video)
+                        end function
+                        end namespace
+                        namespace logger
+                        enum Direction
+                            up
+                        end enum
+                        end namespace
+                        namespace logger
+                        interface Video
+                            uri as string
+                        end interface
                         end namespace
                     `
                 ]

--- a/src/prefixer/RopmModule.ts
+++ b/src/prefixer/RopmModule.ts
@@ -392,8 +392,31 @@ export class RopmModule {
                     }
                 }
 
-                //prefix d.bs class references
-                for (const ref of file.classReferences) {
+                //wrap un-namespaced enums with prefix namespace
+                for (const declaration of file.enumDeclarations) {
+                    if (!declaration.hasNamespace) {
+                        file.addEdit(declaration.startOffset, declaration.startOffset, `namespace ${brighterscriptPrefix}\n`);
+                        file.addEdit(declaration.endOffset, declaration.endOffset, `\nend namespace`);
+                    }
+                }
+
+                //wrap un-namespaced consts with prefix namespace
+                for (const declaration of file.constDeclarations) {
+                    if (!declaration.hasNamespace) {
+                        file.addEdit(declaration.startOffset, declaration.startOffset, `namespace ${brighterscriptPrefix}\n`);
+                        file.addEdit(declaration.endOffset, declaration.endOffset, `\nend namespace`);
+                    }
+                }
+
+                for (const declaration of file.interfaceDeclarations) {
+                    if (!declaration.hasNamespace) {
+                        file.addEdit(declaration.startOffset, declaration.startOffset, `namespace ${brighterscriptPrefix}\n`);
+                        file.addEdit(declaration.endOffset, declaration.endOffset, `\nend namespace`);
+                    }
+                }
+
+                //prefix d.bs custom references
+                for (const ref of file.prefixableReferences) {
                     const baseNamespace = util.getBaseNamespace(ref.fullyQualifiedName);
 
                     const alias = getAlias(baseNamespace);

--- a/src/prefixer/RopmModule.ts
+++ b/src/prefixer/RopmModule.ts
@@ -384,34 +384,11 @@ export class RopmModule {
                     }
                 }
 
-                //wrap un-namespaced classes with prefix namespace
-                for (const cls of file.classDeclarations) {
+                //wrap un-namespaced classes, enums, namespaces, etc... with prefix namespace
+                for (const cls of file.prefixableDeclarations) {
                     if (!cls.hasNamespace) {
                         file.addEdit(cls.startOffset, cls.startOffset, `namespace ${brighterscriptPrefix}\n`);
                         file.addEdit(cls.endOffset, cls.endOffset, `\nend namespace`);
-                    }
-                }
-
-                //wrap un-namespaced enums with prefix namespace
-                for (const declaration of file.enumDeclarations) {
-                    if (!declaration.hasNamespace) {
-                        file.addEdit(declaration.startOffset, declaration.startOffset, `namespace ${brighterscriptPrefix}\n`);
-                        file.addEdit(declaration.endOffset, declaration.endOffset, `\nend namespace`);
-                    }
-                }
-
-                //wrap un-namespaced consts with prefix namespace
-                for (const declaration of file.constDeclarations) {
-                    if (!declaration.hasNamespace) {
-                        file.addEdit(declaration.startOffset, declaration.startOffset, `namespace ${brighterscriptPrefix}\n`);
-                        file.addEdit(declaration.endOffset, declaration.endOffset, `\nend namespace`);
-                    }
-                }
-
-                for (const declaration of file.interfaceDeclarations) {
-                    if (!declaration.hasNamespace) {
-                        file.addEdit(declaration.startOffset, declaration.startOffset, `namespace ${brighterscriptPrefix}\n`);
-                        file.addEdit(declaration.endOffset, declaration.endOffset, `\nend namespace`);
                     }
                 }
 


### PR DESCRIPTION
Fixes a pretty big bug where ropm doesn't understand root-level enums, interfaces, or constants! 

- now properly wraps top-level enums, constants, and interfaces with the prefixed namespaces
- prefixes interface and class member types with the prefix namespaces