### PR TITLE
Fix EINVAL crash

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -81,7 +81,7 @@ describe('Util', () => {
             });
             await util.spawnAsync('noop');
             expect(stub.getCalls()[0].args).to.eql([
-                'noop', [], { stdio: 'inherit' }
+                'noop', [], { stdio: 'inherit', shell: true, windowsHide: true }
             ]);
         });
     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,7 +25,8 @@ export class Util {
             const child = childProcess.spawn(command, args ?? [], {
                 ...(options ?? {}),
                 stdio: 'inherit',
-                shell: true
+                shell: true,
+                windowsHide: true
             });
             child.addListener('error', reject);
             child.addListener('exit', resolve);

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,7 +24,8 @@ export class Util {
         return new Promise((resolve, reject) => {
             const child = childProcess.spawn(command, args ?? [], {
                 ...(options ?? {}),
-                stdio: 'inherit'
+                stdio: 'inherit',
+                shell: true
             });
             child.addListener('error', reject);
             child.addListener('exit', resolve);


### PR DESCRIPTION
Related Issues:
- [EINVAL crash on latest nodejs](https://github.com/rokucommunity/ropm/issues/77)

> There's a weird crash with the latest version of NodeJS when running ropm.

```$ ropm install roku-requests
Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:421:11)
    at Object.spawn (node:child_process:760:9)
    at C:\Users\bronley\AppData\Roaming\npm\node_modules\ropm\dist\util.js:24:40
    at new Promise (<anonymous>)
    at Util.spawnAsync (C:\Users\bronley\AppData\Roaming\npm\node_modules\ropm\dist\util.js:23:16)
    at Util.spawnNpmAsync (C:\Users\bronley\AppData\Roaming\npm\node_modules\ropm\dist\util.js:37:21)
    at InstallCommand.npmInstall (C:\Users\bronley\AppData\Roaming\npm\node_modules\ropm\dist\commands\InstallCommand.js:70:27)
    at async InstallCommand.run (C:\Users\bronley\AppData\Roaming\npm\node_modules\ropm\dist\commands\InstallCommand.js:39:13) {
  errno: -4071,
  code: 'EINVAL',
  syscall: 'spawn'
} ```

Adding `shell: true` fixes the crash