### PR TITLE
Fix test not in a describe, upgrade to bsc `v0.69.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "1.0.10",
-        "brighterscript": "^0.68.4",
+        "brighterscript": "^0.69.0",
         "del": "6.0.0",
         "fs-extra": "9.1.0",
         "glob-all": "3.2.1",
@@ -1856,10 +1856,9 @@
       }
     },
     "node_modules/brighterscript": {
-      "version": "0.68.4",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.68.4.tgz",
-      "integrity": "sha512-hjt2U2U2hWWJD4py6x9XV6lFBp7S7h0KvizSmaXg7D+QWHwC/jR3OBeyqwLrAOW8GYQkez6zb3oRlg2Tr2o8cQ==",
-      "license": "MIT",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.69.0.tgz",
+      "integrity": "sha512-vbtFeuXJyS2ISGPeEpoo9J1ReyDc65rJUUSUehovVRELOtOhcwdh0VQ1UxNkCBYFpJ5bTBCsSEelJiRqsZ8Rag==",
       "dependencies": {
         "@rokucommunity/bslib": "^0.1.1",
         "@rokucommunity/logger": "^0.3.9",
@@ -1875,9 +1874,12 @@
         "fast-glob": "^3.2.12",
         "file-url": "^3.0.0",
         "fs-extra": "^8.1.0",
+        "ignore": "^5.3.1",
         "jsonc-parser": "^2.3.0",
+        "lodash.isequal": "^4.5.0",
         "long": "^3.2.0",
         "luxon": "^2.5.2",
+        "micromatch": "^4.0.4",
         "minimatch": "^3.0.4",
         "moment": "^2.23.0",
         "p-settle": "^2.1.0",
@@ -1885,8 +1887,10 @@
         "readline": "^1.3.0",
         "require-relative": "^0.8.7",
         "roku-deploy": "^3.12.4",
+        "safe-json-stringify": "^1.2.0",
         "serialize-error": "^7.0.1",
         "source-map": "^0.7.4",
+        "thenby": "^1.3.4",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-languageserver-textdocument": "^1.0.11",
@@ -5433,6 +5437,12 @@
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
+    },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -7667,6 +7677,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/thenby": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ=="
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -9808,9 +9823,9 @@
       }
     },
     "brighterscript": {
-      "version": "0.68.4",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.68.4.tgz",
-      "integrity": "sha512-hjt2U2U2hWWJD4py6x9XV6lFBp7S7h0KvizSmaXg7D+QWHwC/jR3OBeyqwLrAOW8GYQkez6zb3oRlg2Tr2o8cQ==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.69.0.tgz",
+      "integrity": "sha512-vbtFeuXJyS2ISGPeEpoo9J1ReyDc65rJUUSUehovVRELOtOhcwdh0VQ1UxNkCBYFpJ5bTBCsSEelJiRqsZ8Rag==",
       "requires": {
         "@rokucommunity/bslib": "^0.1.1",
         "@rokucommunity/logger": "^0.3.9",
@@ -9826,9 +9841,12 @@
         "fast-glob": "^3.2.12",
         "file-url": "^3.0.0",
         "fs-extra": "^8.1.0",
+        "ignore": "^5.3.1",
         "jsonc-parser": "^2.3.0",
+        "lodash.isequal": "^4.5.0",
         "long": "^3.2.0",
         "luxon": "^2.5.2",
+        "micromatch": "^4.0.4",
         "minimatch": "^3.0.4",
         "moment": "^2.23.0",
         "p-settle": "^2.1.0",
@@ -9836,8 +9854,10 @@
         "readline": "^1.3.0",
         "require-relative": "^0.8.7",
         "roku-deploy": "^3.12.4",
+        "safe-json-stringify": "^1.2.0",
         "serialize-error": "^7.0.1",
         "source-map": "^0.7.4",
+        "thenby": "^1.3.4",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-languageserver-textdocument": "^1.0.11",
@@ -12417,6 +12437,11 @@
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -14079,6 +14104,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "thenby": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "1.0.10",
-    "brighterscript": "^0.68.4",
+    "brighterscript": "^0.69.0",
     "del": "6.0.0",
     "fs-extra": "9.1.0",
     "glob-all": "3.2.1",

--- a/src/prefixer/RopmModule.spec.ts
+++ b/src/prefixer/RopmModule.spec.ts
@@ -171,21 +171,23 @@ describe('RopmModule', () => {
     });
 
     describe('getDistinctComponentReferenceNames', () => {
-        const [logger] = createProjects(hostDir, hostDir, {
-            name: 'host',
-            dependencies: [{
-                name: 'logger'
-            }]
+        it('finds component1', () => {
+            const [logger] = createProjects(hostDir, hostDir, {
+                name: 'host',
+                dependencies: [{
+                    name: 'logger'
+                }]
+            });
+            logger.files = [{
+                componentReferences: [{
+                    name: 'Component1'
+                }]
+            }, {
+                componentReferences: [{
+                    name: 'Component1'
+                }]
+            }] as any[];
+            expect(logger.getDistinctComponentReferenceNames()).to.eql(['component1']);
         });
-        logger.files = [{
-            componentReferences: [{
-                name: 'Component1'
-            }]
-        }, {
-            componentReferences: [{
-                name: 'Component1'
-            }]
-        }] as any[];
-        expect(logger.getDistinctComponentReferenceNames()).to.eql(['component1']);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
         "noUnusedLocals": true,
         "allowSyntheticDefaultImports": true,
         "lib": [
-            "es2017",
+            "es2020",
             "es2019.array"
         ]
     },


### PR DESCRIPTION
Fix a test that was not correctly within an `it()` block, and upgrade to bsc `v0.69.0`