### PR TITLE
Fix prefixing bugs for d.bs parameter default values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@rokucommunity/logger": "^0.3.11",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "1.0.10",
-        "brighterscript": "^0.69.10",
+        "brighterscript": "https://github.com/rokucommunity/brighterscript/releases/download/v0.0.0-packages/brighterscript-0.69.12-get-root-expression.20250725180450.tgz",
         "del": "6.0.0",
         "fs-extra": "9.1.0",
         "glob-all": "3.2.1",
@@ -1857,9 +1857,10 @@
       }
     },
     "node_modules/brighterscript": {
-      "version": "0.69.10",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.69.10.tgz",
-      "integrity": "sha512-E8QCzN5bueG+SYJUdQ+1vw/frIV3WrpvoLgbNkAhYLOC6bSwoqmETwmgaiXpnY66Qe2zeAapXCbBcWVVIA7AQA==",
+      "version": "0.69.12-get-root-expression.20250725180450",
+      "resolved": "https://github.com/rokucommunity/brighterscript/releases/download/v0.0.0-packages/brighterscript-0.69.12-get-root-expression.20250725180450.tgz",
+      "integrity": "sha512-/1zj36IyyiUSwrgEEZOtKDoHnd+oGk4jdwTLXmbCEyiUVhw3vn1K7+5c7qlMUMS5U+3SSdLYU3KF9WlqJrQBxw==",
+      "license": "MIT",
       "dependencies": {
         "@rokucommunity/bslib": "^0.1.1",
         "@rokucommunity/logger": "^0.3.11",
@@ -9824,9 +9825,8 @@
       }
     },
     "brighterscript": {
-      "version": "0.69.10",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.69.10.tgz",
-      "integrity": "sha512-E8QCzN5bueG+SYJUdQ+1vw/frIV3WrpvoLgbNkAhYLOC6bSwoqmETwmgaiXpnY66Qe2zeAapXCbBcWVVIA7AQA==",
+      "version": "https://github.com/rokucommunity/brighterscript/releases/download/v0.0.0-packages/brighterscript-0.69.12-get-root-expression.20250725180450.tgz",
+      "integrity": "sha512-/1zj36IyyiUSwrgEEZOtKDoHnd+oGk4jdwTLXmbCEyiUVhw3vn1K7+5c7qlMUMS5U+3SSdLYU3KF9WlqJrQBxw==",
       "requires": {
         "@rokucommunity/bslib": "^0.1.1",
         "@rokucommunity/logger": "^0.3.11",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@rokucommunity/logger": "^0.3.11",
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "1.0.10",
-    "brighterscript": "^0.69.10",
+    "brighterscript": "https://github.com/rokucommunity/brighterscript/releases/download/v0.0.0-packages/brighterscript-0.69.12-get-root-expression.20250725180450.tgz",
     "del": "6.0.0",
     "fs-extra": "9.1.0",
     "glob-all": "3.2.1",

--- a/src/prefixer/ModuleManager.spec.ts
+++ b/src/prefixer/ModuleManager.spec.ts
@@ -1813,6 +1813,122 @@ describe('ModuleManager', () => {
             });
         });
 
+        it('correctly prefixes default param function value', async () => {
+            await testProcess({
+                'logger:source/test.brs': [
+                    trim`
+                        function do_something()
+                        end function
+                        function test(cb1 = do_something, cb2 = do_something)
+                        end function
+                    `,
+                    trim`
+                        function logger_do_something()
+                        end function
+                        function logger_test(cb1 = logger_do_something, cb2 = logger_do_something)
+                        end function
+                    `
+                ]
+            });
+        });
+
+        it('prefixes underscored function name in brs referenced from d.bs', async () => {
+            await testProcess({
+                'logger:source/lib.d.bs': [
+                    trim`
+                        namespace alpha
+                            function beta()
+                            end function
+                        end namespace
+                    `,
+                    trim`
+                        namespace logger.alpha
+                            function beta()
+                            end function
+                        end namespace
+                    `
+                ],
+                'logger:source/main.brs': [
+                    trim`
+                        function doSomething()
+                            alpha_beta()
+                        end function
+                    `,
+                    trim`
+                        function logger_doSomething()
+                            logger_alpha_beta()
+                        end function
+                    `
+                ]
+            });
+        });
+
+        it.only('prefixes default param value when it is a namespaced function ref', async () => {
+            await testProcess({
+                'logger:source/lib.d.bs': [
+                    trim`
+                        namespace alpha
+                            function beta(p1 = invalid)
+                            end function
+                        end namespace
+
+                        function doSomething(cb1 = alpha.beta, cb2 = alpha_beta, cb3 = alpha.beta(alpha_beta()), cb4 = alpha_beta(alpha.beta()))
+                        end function
+                    `,
+                    trim`
+                        namespace logger.alpha
+                            function beta(p1 = invalid)
+                            end function
+                        end namespace
+
+                        namespace logger
+                        function doSomething(cb1 = logger.alpha.beta, cb2 = logger.alpha.beta, cb3 = logger.alpha.beta(logger.alpha.beta()), cb4 = logger.alpha.beta(logger.alpha.beta)))
+                        end function
+                        end namespace
+                    `
+                ]
+            });
+        });
+
+        it.skip('prefixes enums, classes, and interfaces in class members', async () => {
+            await testProcess({
+                'rooibos_promises@@rokucommunity/promises:source/promises.d.bs': [
+                    trim`
+                        class Movie
+                            whichWay as Direction
+                            thingToPlay as Video
+                            parent as Movie
+                        end class
+                        enum Direction
+                            up
+                        end enum
+                        interface Video
+                            uri as string
+                        end interface
+                    `,
+                    trim`
+                        namespace logger
+                        class Movie
+                            whichWay as logger.Direction
+                            thingToPlay as logger.Video
+                            parent as logger.Movie
+                        end class
+                        end namespace
+                        namespace logger
+                        enum Direction
+                            up
+                        end enum
+                        end namespace
+                        namespace logger
+                        interface Video
+                            uri as string
+                        end interface
+                        end namespace
+                    `
+                ]
+            });
+        });
+
         it('prefixes enums, classes, and interfaces in class members', async () => {
             await testProcess({
                 'logger:source/lib.d.bs': [

--- a/src/util.ts
+++ b/src/util.ts
@@ -234,7 +234,7 @@ export class Util {
     }
 
     /**
-     * Replace the first case-insensitive occurance of {search} in {subject} with {replace}
+     * Replace the first case-insensitive occurrence of {search} in {subject} with {replace}
      */
     public replaceCaseInsensitive(search: string, subject: string, replace: string) {
         const idx = subject.toLowerCase().indexOf(search.toLowerCase());
@@ -281,7 +281,7 @@ export class Util {
 
     /**
      * Replaces the Program.validate call with an empty function.
-     * This allows us to bypass BrighterScript's validation cycle, which speeds up performace
+     * This allows us to bypass BrighterScript's validation cycle, which speeds up performance
      */
     public mockProgramValidate() {
         if (Program.prototype.validate !== mockProgramValidate) {
@@ -302,7 +302,6 @@ export class Util {
     public createLogger(prefix = 'ropm:'): Logger {
         return logger.createLogger({ prefix: prefix, printLogLevel: false, printTimestamp: false });
     }
-
 }
 
 function mockProgramValidate() {


### PR DESCRIPTION
Fix bugs in the prefixer related to d.bs default parameters. For example, `lib.d.bs`:


```brighterscript

function doSomething(cb1 = alpha.beta)
end function
```

Should now properly get prefixed to:
```brighterscript
namespace logger
    function doSomething(cb1 = logger.alpha.beta)
    end function
end namespace
```

Also works for default values such as:
- `p1 = alpha.beta()`
- `p2 = someFunc(alpha.beta())`
- `p3 = alpha_beta`
- `p4 = alpha_beta()`