### PR TITLE
Fix Issues with npm-ls

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,31 +8,14 @@ import { CleanCommand } from './commands/CleanCommand';
 import { UninstallCommand } from './commands/UninstallCommand';
 import { CopyCommand } from './commands/CopyCommand';
 
-const argDefinitions: Record<string, yargs.Options> = {
-    cwd: {
-        type: 'string',
-        description: 'The current working directory that should be used to run the command'
-    },
-    force: {
-        type: 'boolean',
-        default: false,
-        description: 'Skip all questions'
-    },
-    logLevel: {
-        type: 'string',
-        choices: ['error', 'warn', 'log', 'info', 'debug'],
-        description: 'The log level. Value can be "error", "warn", "log", "info", "debug".'
-    }
-};
-
 new Promise((resolve, reject) => {
     // eslint-disable-next-line
     yargs
         .command('init', 'Initialize a new package.json file for ropm', (builder) => {
             return builder
-                .option('cwd', argDefinitions.cwd)
-                .option('force', argDefinitions.force)
-                .option('log-level', argDefinitions.logLevel)
+                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' })
+                .option('force', { type: 'boolean', description: 'Skip all questions', default: false })
+                .option('log-level', { type: 'string', defaultDescription: '"log"', description: 'The log level. Value can be "error", "warn", "log", "info", "debug".', choices: ['error', 'warn', 'log', 'info', 'debug'] })
                 .alias('f', 'force')
                 .alias('yes', 'force')
                 .alias('y', 'force');
@@ -47,8 +30,8 @@ new Promise((resolve, reject) => {
             'i'
         ], 'Download Roku dependencies into the roku_modules folder', (builder) => {
             return builder
-                .option('cwd', argDefinitions.cwd)
-                .option('log-level', argDefinitions.logLevel);
+                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' })
+                .option('log-level', { type: 'string', defaultDescription: '"log"', description: 'The log level. Value can be "error", "warn", "log", "info", "debug".', choices: ['error', 'warn', 'log', 'info', 'debug'] });
         }, (args: any) => {
             const command = new InstallCommand(args);
             command.run().then(resolve, reject);
@@ -56,8 +39,8 @@ new Promise((resolve, reject) => {
 
         .command('clean', 'Remove all roku_module files and folders from the root directory', (builder) => {
             return builder
-                .option('cwd', argDefinitions.cwd)
-                .option('log-level', argDefinitions.logLevel);
+                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' })
+                .option('log-level', { type: 'string', defaultDescription: '"log"', description: 'The log level. Value can be "error", "warn", "log", "info", "debug".', choices: ['error', 'warn', 'log', 'info', 'debug'] });
         }, (args: any) => {
             const command = new CleanCommand(args);
             command.run().then(resolve, reject);
@@ -65,8 +48,8 @@ new Promise((resolve, reject) => {
 
         .command('copy', 'Runs `clean` and then installs all ropm modules. Operates solely with the modules already downloaded, and will not download new modules from the registry.', (builder) => {
             return builder
-                .option('cwd', argDefinitions.cwd)
-                .option('log-level', argDefinitions.logLevel);
+                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' })
+                .option('log-level', { type: 'string', defaultDescription: '"log"', description: 'The log level. Value can be "error", "warn", "log", "info", "debug".', choices: ['error', 'warn', 'log', 'info', 'debug'] });
         }, (args: any) => {
             const command = new CopyCommand(args);
             command.run().then(resolve, reject);
@@ -77,8 +60,8 @@ new Promise((resolve, reject) => {
             'un', 'unlink', 'remove', 'rm', 'r'
         ], 'Uninstall the specified dependencies', (builder) => {
             return builder
-                .option('cwd', argDefinitions.cwd)
-                .option('log-level', argDefinitions.logLevel);
+                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' })
+                .option('log-level', { type: 'string', defaultDescription: '"log"', description: 'The log level. Value can be "error", "warn", "log", "info", "debug".', choices: ['error', 'warn', 'log', 'info', 'debug'] });
         }, (args: any) => {
             const command = new UninstallCommand(args);
             command.run().then(resolve, reject);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,14 +8,31 @@ import { CleanCommand } from './commands/CleanCommand';
 import { UninstallCommand } from './commands/UninstallCommand';
 import { CopyCommand } from './commands/CopyCommand';
 
+const argDefinitions: Record<string, yargs.Options> = {
+    cwd: {
+        type: 'string',
+        description: 'The current working directory that should be used to run the command'
+    },
+    force: {
+        type: 'boolean',
+        default: false,
+        description: 'Skip all questions'
+    },
+    logLevel: {
+        type: 'string',
+        choices: ['error', 'warn', 'log', 'info', 'debug'],
+        description: 'The log level. Value can be "error", "warn", "log", "info", "debug".'
+    }
+};
+
 new Promise((resolve, reject) => {
     // eslint-disable-next-line
     yargs
         .command('init', 'Initialize a new package.json file for ropm', (builder) => {
             return builder
-                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' })
-                .option('force', { type: 'boolean', description: 'Skip all questions', default: false })
-                .option('log-level', { type: 'string', defaultDescription: '"log"', description: 'The log level. Value can be "error", "warn", "log", "info", "debug".', choices: ['error', 'warn', 'log', 'info', 'debug'] })
+                .option('cwd', argDefinitions.cwd)
+                .option('force', argDefinitions.force)
+                .option('log-level', argDefinitions.logLevel)
                 .alias('f', 'force')
                 .alias('yes', 'force')
                 .alias('y', 'force');
@@ -30,8 +47,8 @@ new Promise((resolve, reject) => {
             'i'
         ], 'Download Roku dependencies into the roku_modules folder', (builder) => {
             return builder
-                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' })
-                .option('log-level', { type: 'string', defaultDescription: '"log"', description: 'The log level. Value can be "error", "warn", "log", "info", "debug".', choices: ['error', 'warn', 'log', 'info', 'debug'] });
+                .option('cwd', argDefinitions.cwd)
+                .option('log-level', argDefinitions.logLevel);
         }, (args: any) => {
             const command = new InstallCommand(args);
             command.run().then(resolve, reject);
@@ -39,8 +56,8 @@ new Promise((resolve, reject) => {
 
         .command('clean', 'Remove all roku_module files and folders from the root directory', (builder) => {
             return builder
-                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' })
-                .option('log-level', { type: 'string', defaultDescription: '"log"', description: 'The log level. Value can be "error", "warn", "log", "info", "debug".', choices: ['error', 'warn', 'log', 'info', 'debug'] });
+                .option('cwd', argDefinitions.cwd)
+                .option('log-level', argDefinitions.logLevel);
         }, (args: any) => {
             const command = new CleanCommand(args);
             command.run().then(resolve, reject);
@@ -48,8 +65,8 @@ new Promise((resolve, reject) => {
 
         .command('copy', 'Runs `clean` and then installs all ropm modules. Operates solely with the modules already downloaded, and will not download new modules from the registry.', (builder) => {
             return builder
-                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' })
-                .option('log-level', { type: 'string', defaultDescription: '"log"', description: 'The log level. Value can be "error", "warn", "log", "info", "debug".', choices: ['error', 'warn', 'log', 'info', 'debug'] });
+                .option('cwd', argDefinitions.cwd)
+                .option('log-level', argDefinitions.logLevel);
         }, (args: any) => {
             const command = new CopyCommand(args);
             command.run().then(resolve, reject);
@@ -60,8 +77,8 @@ new Promise((resolve, reject) => {
             'un', 'unlink', 'remove', 'rm', 'r'
         ], 'Uninstall the specified dependencies', (builder) => {
             return builder
-                .option('cwd', { type: 'string', description: 'The current working directory that should be used to run the command' })
-                .option('log-level', { type: 'string', defaultDescription: '"log"', description: 'The log level. Value can be "error", "warn", "log", "info", "debug".', choices: ['error', 'warn', 'log', 'info', 'debug'] });
+                .option('cwd', argDefinitions.cwd)
+                .option('log-level', argDefinitions.logLevel);
         }, (args: any) => {
             const command = new UninstallCommand(args);
             command.run().then(resolve, reject);

--- a/src/commands/InstallCommand.spec.ts
+++ b/src/commands/InstallCommand.spec.ts
@@ -259,26 +259,6 @@ describe('InstallCommand', () => {
 
         });
 
-        it('shows underlying error when `npm ls` fails', async () => {
-            writeProject(projectName, {
-                'source/main.brs': '',
-                //a "leftover" file from a previous ropm install
-                'customDir/roku_modules/testlib/file.brs': ''
-            }, {
-                dependencies: {
-                    'logger': `file:../logger`
-                }
-            });
-
-            let ex;
-            try {
-                await command.run();
-            } catch (e) {
-                ex = e;
-            }
-            expect(ex.message).to.include('Failed to compute prod dependencies');
-        });
-
         it('ignores prod dependencies that are missing the "ropm" keyword', async () => {
             writeProject('logger', {
                 'source/logger.brs': ''

--- a/src/commands/InstallCommand.ts
+++ b/src/commands/InstallCommand.ts
@@ -1,4 +1,4 @@
-import type { CommandArgs, RopmPackageJson, ModuleDependencyError } from '../util';
+import type { CommandArgs, RopmPackageJson } from '../util';
 import { util } from '../util';
 import * as path from 'path';
 import * as childProcess from 'child_process';
@@ -98,20 +98,7 @@ export class InstallCommand {
 
         //remove the host module from the list (it should always be the first entry)
         const hostModulePath = modulePaths.splice(0, 1)[0];
-
-        try {
-            this.moduleManager.hostDependencies = await util.getModuleDependencies(hostModulePath);
-
-        } catch (e) {
-            const moduleErr = (e as ModuleDependencyError);
-            const resolvedDependencies = moduleErr.resolved;
-            if (resolvedDependencies.length === 0) {
-                throw e;
-            }
-
-            this.logger.warn(moduleErr.message);
-            this.moduleManager.hostDependencies = resolvedDependencies;
-        }
+        this.moduleManager.hostDependencies = await util.getModuleDependencies(hostModulePath, this.logger);
 
         this.moduleManager.hostRootDir = this.hostRootDir;
         this.moduleManager.noprefixNpmAliases = this.hostPackageJson?.ropm?.noprefix ?? [];
@@ -169,6 +156,4 @@ export interface InstallCommandArgs extends CommandArgs {
      * it will override the value from package.json.
      */
     rootDir?: string;
-    depth?: number;
-    omit?: string;
 }

--- a/src/commands/InstallCommand.ts
+++ b/src/commands/InstallCommand.ts
@@ -122,18 +122,23 @@ export class InstallCommand {
         }
         let stdout: string;
         try {
-            stdout = childProcess.execSync('npm ls --parseable --prod --depth=Infinity', {
+            const npmLs = `npm ls --parseable --omit=dev --omit=optional --depth=Infinity`;
+            this.logger.debug(`executing command: ${npmLs}`);
+
+            stdout = childProcess.execSync(npmLs, {
                 cwd: this.cwd
             }).toString();
+
         } catch (e) {
             stdout = (e as any).stdout.toString();
-            const stderr: string = (e as any).stderr.toString();
-            //sometimes the unit tests absorb stderr...so as long as we have stdout, assume it's valid (and ignore the stderr)
-            if (stderr.includes('npm ERR! extraneous:')) {
-                //ignore errors
-            } else {
-                throw new Error('Failed to compute prod dependencies: ' +  (e as any).message);
-            }
+
+            // do not throw error, just log a warning
+            // there are a lot of edge cases where npm ls errors don't pose any actual roadblock for ropm packages
+
+            this.logger.warn([
+                'Encountered an error while retrieving the prod dependencies from npm-ls. Attempting to proceed anyways. You can review the error below:\n',
+                (e as any).message
+            ].join('\n'));
         }
 
         return stdout.trim().split(/\r?\n/);


### PR DESCRIPTION
# Proposed Changes

- updated `--prod` flag to use `--omit=dev --omit=optional` to resolve deprecation warning and prevent processing optional packages
- updated the ropm project so that it prints warnings instead of throwing errors and attempts to proceed with the install steps
- this is to resolve false errors (listed under #Context) that prevent ropm from installing even when it should succeed

# Context

- ropm is currently using the command `npm ls --parseable --prod --depth=Infinity`

This produces a few problems:

### [#114 `--prod` is deprecated and will stop working with next major version of npm](https://github.com/rokucommunity/ropm/issues/114)

<details>
<summary>Issue Description</summary>

> ```
> npm warn Expanding --prod to --production. This will stop working in the next major version of npm.
> npm warn config production Use `--omit=dev` instead.
> ```

</details>

### [#115 ropm crashes when trying to read optionalDependencies](https://github.com/rokucommunity/ropm/issues/115)

<details>
<summary>Issue Description</summary>

> * run `ropm copy` on Windows with optional dependency `fsevents`
> * fsevents is not supported on Windows, it is not possible to install
>   
>   * `Unsupported platform for fsevents@2.3.3: wanted {"os":"darwin"} (current: {"os":"win32"})`
> 
> When ropm attempts to find package.json, it is unable to and crashes.. it's unable to because it's an optional dependency that is not permitted to be installed on Windows.. so there isn't much I can do about it :(
> 
> `mocha` is using `fsevents` as a child dependency..
> 
> ```
> > npx ropm copy
> 
> npm warn Expanding --prod to --production. This will stop working in the next major version of npm.
> npm warn config production Use `--omit=dev` instead.
> [Error: ENOENT: no such file or directory, open 'C:\Users\heart\Repositories\nba\NextGen-Roku\node_modules\fsevents\package.json'] {
>   errno: -4058,
>   code: 'ENOENT',
>   syscall: 'open',
>   path: 'C:\\Users\\heart\\Repositories\\nba\\NextGen-Roku\\node_modules\\fsevents\\package.json'
> }
> ```
</details>

  - This can be resolved by `--omit=optional`

### [#117 ropm is processing all prod dependencies, not just the dependencies listed in package.json](https://github.com/rokucommunity/ropm/issues/117)

<details>
<summary>Issue Description</summary>
> ropm is using the command `npm ls --parseable --prod --depth=Infinity`
> 
> * the argument `--depth=Infinity` results in attempting to parse both direct dependencies (explicitly defined in package.json) AND all transitive dependencies (the dependencies of our direct dependencies)
>   
>   * this results in parsing a significantly higher number of packages
>   * ELSPROBLEMS resulting from transitive dependencies that are failing to install do not necessarily affect a project's own npm scripts (e.g., if brighterscript's dependency for `source-map` doesn't install, that poses no real problem for running brighterscript commands) **_but it will throw errors in `npm ls`, resulting in an unresolvable error state_**
> 
> I understand that the intent of `--depth=Infinity` was to provide a way for direct dependencies to declare a ropm dependency without actually including it in their `dist` files, however this can cause a lot of problems.
> 
> I would propose that this parameter should be configurable when using `ropm`

</details>

- this is resolved by _not_ throwing an error. Instead printing a warning message and proceeding
