### PR TITLE
Increase install buffer for json

### DIFF
--- a/src/commands/InstallCommand.ts
+++ b/src/commands/InstallCommand.ts
@@ -127,7 +127,7 @@ export class InstallCommand {
 
             stdout = childProcess.execSync(npmLs, {
                 cwd: this.cwd,
-                maxBuffer: 50 * 1024 * 1024 // 50MB buffer to handle large dependency trees
+                maxBuffer: 500 * 1024 * 1024 // 500MB buffer to handle large dependency trees (this is ridiculously large, but better than crashing...)
             }).toString();
         } catch (e: any) {
             stdout = (e as any).stdout.toString();


### PR DESCRIPTION
ropm install within a pnpm project, might have hundreds of thousands of flattened modules. this can quickly cause our input json buffer to be pretty large. Increases to 500 megabytes (which is HUGE, but better than crashing). 