### PR TITLE
Replace @xml-tools/ast with in-repo shim

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
         "**/.DS_Store": true,
         "**/node_modules": true,
         "**/coverage": true
-    }
+    },
+    "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@rokucommunity/logger": "^0.3.11",
-        "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "1.0.10",
         "brighterscript": "^0.72.1",
         "del": "6.0.0",
@@ -1387,32 +1386,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
-    },
-    "node_modules/@xml-tools/ast": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@xml-tools/ast/-/ast-5.0.5.tgz",
-      "integrity": "sha512-avvzTOvGplCx9JSKdsTe3vK+ACvsHy2HxVfkcfIqPzu+kF5CT4rw5aUVzs0tJF4cnDyMRVkSyVxR07X0Px8gPA==",
-      "dependencies": {
-        "@xml-tools/common": "^0.1.6",
-        "@xml-tools/parser": "^1.0.11",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@xml-tools/ast/node_modules/@xml-tools/parser": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
-      "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
-      "dependencies": {
-        "chevrotain": "7.1.1"
-      }
-    },
-    "node_modules/@xml-tools/common": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@xml-tools/common/-/common-0.1.6.tgz",
-      "integrity": "sha512-7aVZeEYccs1KI/Asd6KKnrB4dTAWXTkjRMjG40ApGEUp5NpfQIvWLEBvMv85Koj2lbSpagcAERwDy9qMsfWGdA==",
-      "dependencies": {
-        "lodash": "4.17.21"
-      }
     },
     "node_modules/@xml-tools/parser": {
       "version": "1.0.10",
@@ -9498,34 +9471,6 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
-    "@xml-tools/ast": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@xml-tools/ast/-/ast-5.0.5.tgz",
-      "integrity": "sha512-avvzTOvGplCx9JSKdsTe3vK+ACvsHy2HxVfkcfIqPzu+kF5CT4rw5aUVzs0tJF4cnDyMRVkSyVxR07X0Px8gPA==",
-      "requires": {
-        "@xml-tools/common": "^0.1.6",
-        "@xml-tools/parser": "^1.0.11",
-        "lodash": "^4.18.1"
-      },
-      "dependencies": {
-        "@xml-tools/parser": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
-          "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
-          "requires": {
-            "chevrotain": "7.1.1"
-          }
-        }
-      }
-    },
-    "@xml-tools/common": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@xml-tools/common/-/common-0.1.6.tgz",
-      "integrity": "sha512-7aVZeEYccs1KI/Asd6KKnrB4dTAWXTkjRMjG40ApGEUp5NpfQIvWLEBvMv85Koj2lbSpagcAERwDy9qMsfWGdA==",
-      "requires": {
-        "lodash": "^4.18.1"
-      }
-    },
     "@xml-tools/parser": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.10.tgz",
@@ -13578,7 +13523,7 @@
         "is-glob": "^4.0.3",
         "jsonc-parser": "^2.3.0",
         "jszip": "^3.6.0",
-        "lodash": "^4.18.1",
+        "lodash": "^4.17.21",
         "micromatch": "^4.0.4",
         "moment": "^2.29.1",
         "parse-ms": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "homepage": "https://github.com/rokucommunity/ropm",
   "dependencies": {
     "@rokucommunity/logger": "^0.3.11",
-    "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "1.0.10",
     "brighterscript": "^0.72.1",
     "del": "6.0.0",
@@ -77,7 +76,6 @@
     "typescript": "^5.4.5"
   },
   "overrides": {
-    "lodash": "^4.18.1",
     "serialize-javascript": "^7.0.5"
   },
   "mocha": {

--- a/src/prefixer/File.ts
+++ b/src/prefixer/File.ts
@@ -1,7 +1,7 @@
 import * as fsExtra from 'fs-extra';
 import * as xmlParser from '@xml-tools/parser';
-import type { XMLDocument, XMLElement } from '@xml-tools/ast';
-import { buildAst } from '@xml-tools/ast';
+import type { XMLDocument, XMLElement } from './XmlAst';
+import { buildAst } from './XmlAst';
 import { util } from '../util';
 import * as path from 'path';
 import type { BrsFile, Position, Program, Range, XmlFile, NamespaceStatement } from 'brighterscript';

--- a/src/prefixer/XmlAst.spec.ts
+++ b/src/prefixer/XmlAst.spec.ts
@@ -1,0 +1,198 @@
+import { expect } from 'chai';
+import * as xmlParser from '@xml-tools/parser';
+import { buildAst } from './XmlAst';
+import type { XMLDocument } from './XmlAst';
+
+function parse(text: string): XMLDocument {
+    const { cst, tokenVector } = xmlParser.parse(text);
+    return buildAst(cst as any, tokenVector);
+}
+
+describe('prefixer/XmlAst', () => {
+
+    describe('buildAst', () => {
+        it('yields a defensive empty root element on empty input (matches @xml-tools/ast)', () => {
+            const root = parse('').rootElement!;
+            expect(root.name).to.be.undefined;
+            expect(root.attributes).to.eql([]);
+            expect(root.subElements).to.eql([]);
+            expect(root.syntax.openName).to.be.undefined;
+            expect(root.syntax.closeName).to.be.undefined;
+        });
+
+        it('does not throw on malformed XML', () => {
+            const doc = parse('<component name="A"');
+            expect(doc.rootElement?.name).to.equal('component');
+            expect(doc.rootElement?.attributes[0]?.key).to.equal('name');
+            expect(doc.rootElement?.attributes[0]?.value).to.equal('A');
+        });
+
+        it('tolerates a CST shape with no children', () => {
+            const doc = buildAst({});
+            expect(doc.rootElement).to.be.undefined;
+        });
+
+        it('ignores an XML prolog and still resolves the root element', () => {
+            const doc = parse('<?xml version="1.0" encoding="utf-8"?><component name="A"/>');
+            expect(doc.rootElement?.name).to.equal('component');
+            expect(doc.rootElement?.attributes[0]?.key).to.equal('name');
+            expect(doc.rootElement?.attributes[0]?.value).to.equal('A');
+        });
+    });
+
+    describe('XMLElement', () => {
+        it('captures name, attributes, and the opening token offset on a self-closing element', () => {
+            const text = '<component name="A" extends="B"/>';
+            const doc = parse(text);
+            const root = doc.rootElement!;
+            expect(root.name).to.equal('component');
+            expect(root.subElements).to.eql([]);
+            expect(root.syntax.openName?.image).to.equal('component');
+            expect(root.syntax.openName?.startOffset).to.equal(text.indexOf('component'));
+            // self-closing => no closeName
+            expect(root.syntax.closeName).to.be.undefined;
+        });
+
+        it('captures both opening and closing name tokens on a paired element', () => {
+            const text = '<component></component>';
+            const doc = parse(text);
+            const root = doc.rootElement!;
+            expect(root.syntax.openName?.image).to.equal('component');
+            expect(root.syntax.openName?.startOffset).to.equal(1);
+            expect(root.syntax.closeName?.image).to.equal('component');
+            // </component> starts at index 13, the name itself at 15
+            expect(root.syntax.closeName?.startOffset).to.equal(text.lastIndexOf('component'));
+        });
+
+        it('collects child elements across multiple content blocks (text/comments interleaved)', () => {
+            const text = `<component>
+                text-before
+                <interface></interface>
+                <!-- a comment -->
+                text-between
+                <children></children>
+                <![CDATA[ raw text ]]>
+                text-after
+            </component>`;
+            const root = parse(text).rootElement!;
+            expect(root.subElements.map(x => x.name)).to.eql(['interface', 'children']);
+        });
+
+        it('builds nested subElements recursively', () => {
+            const root = parse('<a><b><c/></b><d/></a>').rootElement!;
+            expect(root.name).to.equal('a');
+            expect(root.subElements.map(x => x.name)).to.eql(['b', 'd']);
+            expect(root.subElements[0].subElements.map(x => x.name)).to.eql(['c']);
+        });
+
+        it('preserves namespace prefixes in element names', () => {
+            const root = parse('<svg:rect width="10"/>').rootElement!;
+            expect(root.name).to.equal('svg:rect');
+        });
+
+        it('does not expose textContents, position, prolog, or namespace metadata', () => {
+            const root = parse('<a foo="bar">some text</a>').rootElement! as any;
+            // sanity: shim surface excludes these — confirming they're not present so consumers don't trip
+            expect(root).to.not.have.property('textContents');
+            expect(root).to.not.have.property('position');
+            expect(root).to.not.have.property('namespaces');
+            expect(root).to.not.have.property('ns');
+            expect(root).to.not.have.property('parent');
+        });
+    });
+
+    describe('XMLAttribute', () => {
+        it('strips surrounding double quotes from value, keeps them in syntax.value.image', () => {
+            const text = '<component name="A"/>';
+            const attr = parse(text).rootElement!.attributes[0];
+            expect(attr.key).to.equal('name');
+            expect(attr.value).to.equal('A');
+            expect(attr.syntax.value?.image).to.equal('"A"');
+            //consumer adds +1 to step past the opening quote
+            expect(attr.syntax.value?.startOffset).to.equal(text.indexOf('"A"'));
+        });
+
+        it('strips surrounding single quotes from value', () => {
+            const attr = parse(`<component name='A'/>`).rootElement!.attributes[0];
+            expect(attr.value).to.equal('A');
+            expect(attr.syntax.value?.image).to.equal(`'A'`);
+        });
+
+        it('handles an empty attribute value', () => {
+            const attr = parse('<component name=""/>').rootElement!.attributes[0];
+            expect(attr.value).to.equal('');
+            expect(attr.syntax.value?.image).to.equal('""');
+        });
+
+        it('returns an empty attributes array when the element has none', () => {
+            expect(parse('<component/>').rootElement!.attributes).to.eql([]);
+        });
+
+        it('preserves attribute order and supports namespace-prefixed keys', () => {
+            const attrs = parse('<a xmlns:x="urn:x" x:foo="1" bar="2"/>').rootElement!.attributes;
+            expect(attrs.map(x => x.key)).to.eql(['xmlns:x', 'x:foo', 'bar']);
+            expect(attrs.map(x => x.value)).to.eql(['urn:x', '1', '2']);
+        });
+
+        it('does not expose position or parent on attributes', () => {
+            const attr = parse('<a foo="bar"/>').rootElement!.attributes[0] as any;
+            expect(attr).to.not.have.property('position');
+            expect(attr).to.not.have.property('parent');
+        });
+    });
+
+    describe('round-trip against File.ts read patterns', () => {
+        // These are the exact access patterns that src/prefixer/File.ts uses.
+        // If any of them blow up here, File.ts will blow up at runtime.
+        it('supports rootElement.attributes.find(x => x.key === ...)', () => {
+            const text = '<component name="MyComponent" extends="Group"/>';
+            const root = parse(text).rootElement!;
+            const nameAttr = root.attributes.find(x => x.key?.toLowerCase() === 'name');
+            expect(nameAttr?.value).to.equal('MyComponent');
+            //File.ts: nameAttribute.syntax.value.startOffset + 1
+            expect(nameAttr!.syntax.value!.startOffset + 1).to.equal(text.indexOf('MyComponent'));
+        });
+
+        it('supports finding <interface> and walking its child <function>/<field> elements', () => {
+            const text = `<component name="A">
+                <interface>
+                    <function name="onClick"/>
+                    <field id="text" onchange="onTextChange"/>
+                </interface>
+            </component>`;
+            const root = parse(text).rootElement!;
+            const iface = root.subElements.find(x => x.name?.toLowerCase() === 'interface')!;
+            expect(iface).to.not.be.undefined;
+
+            const fn = iface.subElements.find(x => x.name === 'function')!;
+            const fnName = fn.attributes.find(x => x.key === 'name')!;
+            expect(fnName.value).to.equal('onClick');
+            expect(fnName.syntax.value!.startOffset + 1).to.equal(text.indexOf('onClick'));
+
+            const field = iface.subElements.find(x => x.name === 'field')!;
+            const onChange = field.attributes.find(x => x.key === 'onchange')!;
+            expect(onChange.value).to.equal('onTextChange');
+            expect(onChange.syntax.value!.startOffset + 1).to.equal(text.indexOf('onTextChange'));
+        });
+
+        it('supports walking <children> and reading openName/closeName offsets', () => {
+            const text = `<component><children><MyChild></MyChild></children></component>`;
+            const root = parse(text).rootElement!;
+            const children = root.subElements.find(x => x.name === 'children')!;
+            const myChild = children.subElements[0];
+            expect(myChild.syntax.openName?.image).to.equal('MyChild');
+            expect(myChild.syntax.openName?.startOffset).to.equal(text.indexOf('MyChild'));
+            expect(myChild.syntax.closeName?.image).to.equal('MyChild');
+            expect(myChild.syntax.closeName?.startOffset).to.equal(text.lastIndexOf('MyChild'));
+        });
+
+        it('supports walking <script uri="..."> attribute offsets', () => {
+            const text = `<component><script uri="pkg:/source/main.brs"/></component>`;
+            const root = parse(text).rootElement!;
+            const script = root.subElements.find(x => x.name === 'script')!;
+            const uri = script.attributes.find(x => x.key === 'uri')!;
+            expect(uri.value).to.equal('pkg:/source/main.brs');
+            expect(uri.syntax.value!.startOffset + 1).to.equal(text.indexOf('pkg:/source/main.brs'));
+        });
+    });
+});

--- a/src/prefixer/XmlAst.ts
+++ b/src/prefixer/XmlAst.ts
@@ -1,0 +1,113 @@
+export interface XMLDocument {
+    rootElement?: XMLElement;
+}
+
+export interface XMLElement {
+    name?: string;
+    attributes: XMLAttribute[];
+    subElements: XMLElement[];
+    syntax: {
+        openName?: XMLToken;
+        closeName?: XMLToken;
+    };
+}
+
+export interface XMLAttribute {
+    key?: string;
+    value?: string;
+    syntax: {
+        value?: XMLToken;
+    };
+}
+
+export interface XMLToken {
+    startOffset: number;
+    image: string;
+}
+
+interface CstLike {
+    children?: Record<string, unknown>;
+}
+
+interface TokenLike {
+    startOffset: number;
+    image: string;
+}
+
+function toToken(token: TokenLike | undefined): XMLToken | undefined {
+    if (!token) {
+        return undefined;
+    }
+    return { startOffset: token.startOffset, image: token.image };
+}
+
+function buildAttribute(attrCst: CstLike): XMLAttribute {
+    const children = (attrCst.children ?? {}) as {
+        Name?: TokenLike[];
+        STRING?: TokenLike[];
+    };
+    const nameToken = children.Name?.[0];
+    const valueToken = children.STRING?.[0];
+
+    let value: string | undefined;
+    if (valueToken && valueToken.image.length >= 2) {
+        //strip surrounding quotes (single or double)
+        value = valueToken.image.slice(1, -1);
+    }
+
+    return {
+        key: nameToken?.image,
+        value: value,
+        syntax: {
+            value: toToken(valueToken)
+        }
+    };
+}
+
+function collectSubElements(contentCsts: CstLike[] | undefined): XMLElement[] {
+    if (!contentCsts) {
+        return [];
+    }
+    const result: XMLElement[] = [];
+    for (const contentCst of contentCsts) {
+        const elements = ((contentCst.children ?? {}) as { element?: CstLike[] }).element;
+        if (elements) {
+            for (const el of elements) {
+                result.push(buildElement(el));
+            }
+        }
+    }
+    return result;
+}
+
+function buildElement(elementCst: CstLike): XMLElement {
+    const children = (elementCst.children ?? {}) as {
+        Name?: TokenLike[];
+        END_NAME?: TokenLike[];
+        attribute?: CstLike[];
+        content?: CstLike[];
+    };
+    const openName = children.Name?.[0];
+    const closeName = children.END_NAME?.[0];
+
+    return {
+        name: openName?.image,
+        attributes: (children.attribute ?? []).map(buildAttribute),
+        subElements: collectSubElements(children.content),
+        syntax: {
+            openName: toToken(openName),
+            closeName: toToken(closeName)
+        }
+    };
+}
+
+/**
+ * Build a minimal XML AST from the CST returned by `@xml-tools/parser`.
+ * Only contains the fields ropm actually consumes.
+ */
+export function buildAst(cst: CstLike, _tokenVector?: unknown): XMLDocument {
+    const rootCst = ((cst.children ?? {}) as { element?: CstLike[] }).element?.[0];
+    return {
+        rootElement: rootCst ? buildElement(rootCst) : undefined
+    };
+}


### PR DESCRIPTION
## Why

`@xml-tools/ast@5.0.5` (the latest published version) pins `lodash: 4.17.21` exactly as a **runtime** dependency. npm `overrides` only apply when the project itself is the root install, so ropm consumers were still receiving the vulnerable lodash transitively, even after the `lodash` override added in #137.

Three open lodash advisories in the affected range (`<=4.17.23`):
- [GHSA-xxjr-mmjv-4gpg](https://github.com/advisories/GHSA-xxjr-mmjv-4gpg) — prototype pollution in `_.unset`/`_.omit` (moderate)
- [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) — code injection via `_.template` (high)
- [GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh) — prototype pollution via array path bypass (moderate)

The leaking chain was:

```
ropm -> @xml-tools/ast -> lodash@4.17.21
ropm -> @xml-tools/ast -> @xml-tools/common -> lodash@4.17.21
```

## What

`@xml-tools/ast` only provided AST sugar over the CST that `@xml-tools/parser` already produces, and `File.ts` only consumed a tiny subset of the AST surface (`name`, `attributes`, `subElements`, plus a few offset tokens — verified by mapping every reference). Replaced it with a small in-repo shim that walks the CST directly.

### Changes
- **New** [`src/prefixer/XmlAst.ts`](src/prefixer/XmlAst.ts) — ~95 LOC. Exposes `XMLDocument` / `XMLElement` / `XMLAttribute` / `XMLToken` interfaces and `buildAst(cst, tokenVector)`. **Zero new runtime deps.**
- **New** [`src/prefixer/XmlAst.spec.ts`](src/prefixer/XmlAst.spec.ts) — 20 tests:
  - `buildAst`: empty input, malformed XML, missing CST `children`, XML prolog handling
  - `XMLElement`: self-closing vs. paired tags, multi-block content (text/comments/CDATA interleaved), nested recursion, namespace-prefixed names, confirms `textContents`/`position`/`namespaces`/`ns`/`parent` are intentionally absent
  - `XMLAttribute`: double-quote strip, single-quote strip, empty value `""`, ordering, namespace-prefixed keys
  - Round-trip against every read pattern `File.ts` actually uses
- [`src/prefixer/File.ts`](src/prefixer/File.ts) — two import lines re-pointed at the new module (no other callsite changes needed; the interface matches exactly)
- [`package.json`](package.json) — drop `@xml-tools/ast` from `dependencies`; drop the `lodash` override (no longer needed)
- [`.vscode/settings.json`](.vscode/settings.json) — `js/ts.tsdk.path` so contributors pick up the workspace TypeScript SDK

## After

```
$ npm run audit
found 0 vulnerabilities

$ npm ls lodash
ropm@0.11.6
└─┬ roku-deploy@3.17.4
  └── lodash@4.18.1
```

The only remaining `lodash` in the runtime tree is `4.18.1`, which is **past** all three advisory ranges. It resolves naturally from `roku-deploy`'s `"lodash": "^4.17.21"` range — no override required.